### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+# The @googleapis/api-bigquery is the default owner for changes in this repo
+*               @googleapis/api-bigquery
+
+# The python-samples-reviewers team is the default owner for samples changes
+/samples/   @googleapis/python-samples-owners
+


### PR DESCRIPTION
Copied from https://github.com/googleapis/python-bigquery/blob/master/.github/CODEOWNERS