### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import io
-from setuptools import setup
+import setuptools
 
 # Package metadata.
 
@@ -39,7 +39,7 @@ def readme():
         return f.read()
 
 
-setup(
+setuptools.setup(
     name=name,
     version=setuptools.sic(version),
     description=description,

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,21 @@
 import io
 import setuptools
 
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
+
 # Package metadata.
 
 name = "pybigquery"
@@ -41,7 +56,7 @@ def readme():
 
 setuptools.setup(
     name=name,
-    version=setuptools.sic(version),
+    version=sic(version),
     description=description,
     long_description=readme(),
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def readme():
 
 setup(
     name=name,
-    version=version,
+    version=setuptools.sic(version),
     description=description,
     long_description=readme(),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from `-patch` to `.patch` which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.