### PR TITLE
fix(deps): pin 'google-{api,cloud}-core', 'google-auth' to allow 2.x versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,10 @@ setup(
     platforms="Posix; MacOS X; Windows",
     install_requires=[
         "google-api-core>=1.30.0",  # Work-around bug in cloud core deps.
-        "google-auth>=1.25.0,<3.0dev",  # Work around pip wack.
+        # NOTE: Maintainers, please do not require google-auth>=2.x.x
+        # Until this issue is closed
+        # https://github.com/googleapis/google-cloud-python/issues/10566
+        "google-auth>=1.25.0,<3.0.0dev",  # Work around pip wack.
         "google-cloud-bigquery>=2.19.0",
         "sqlalchemy>=1.2.0,<1.5.0dev",
         "future",


### PR DESCRIPTION
Expand pins on library dependencies in preparation for these dependencies taking a new major version. See https://github.com/googleapis/google-cloud-python/issues/10566.