### PR TITLE
chore: use public post processor image

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -1,3 +1,3 @@
 docker:
-  image: gcr.io/repo-automation-bots/owlbot-python:latest
-  digest: sha256:1456ea2b3b523ccff5e13030acef56d1de28f21249c62aa0f196265880338fa7
+  image: gcr.io/cloud-devrel-public-resources/owlbot-python:latest
+  digest: sha256:a3a85c2e0b3293068e47b1635b178f7e3d3845f2cfb8722de6713d4bbafdcd1d

--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 docker:
-  image: gcr.io/repo-automation-bots/owlbot-python:latest
+  image: gcr.io/cloud-devrel-public-resources/owlbot-python:latest
 
 begin-after-commit-hash: be22498ce258bf2d5fe12fd696d3ad9a2b6c430e
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,9 +113,9 @@ Coding Style
    export GOOGLE_CLOUD_TESTING_BRANCH="main"
 
   By doing this, you are specifying the location of the most up-to-date
-  version of ``python-bigquery-sqlalchemy``. The the suggested remote name ``upstream``
-  should point to the official ``googleapis`` checkout and the
-  the branch should be the main branch on that remote (``main``).
+  version of ``python-bigquery-sqlalchemy``. The
+  remote name ``upstream`` should point to the official ``googleapis``
+  checkout and the branch should be the default branch on that remote (``main``).
 
 - This repository contains configuration for the
   `pre-commit <https://pre-commit.com/>`__ tool, which automates checking

--- a/owlbot.py
+++ b/owlbot.py
@@ -195,51 +195,6 @@ python_files=tests/*test_*.py
 python.py_samples(skip_readmes=True)
 
 # ----------------------------------------------------------------------------
-# Remove the replacements below once https://github.com/googleapis/synthtool/pull/1188 is merged
-
-# Update googleapis/repo-automation-bots repo to main in .kokoro/*.sh files
-s.replace(".kokoro/*.sh", "repo-automation-bots/tree/master", "repo-automation-bots/tree/main")
-
-# Customize CONTRIBUTING.rst to replace master with main
-s.replace(
-    "CONTRIBUTING.rst",
-    "fetch and merge changes from upstream into master",
-    "fetch and merge changes from upstream into main",
-)
-
-s.replace(
-    "CONTRIBUTING.rst",
-    "git merge upstream/master",
-    "git merge upstream/main",
-)
-
-s.replace(
-    "CONTRIBUTING.rst",
-    """export GOOGLE_CLOUD_TESTING_BRANCH=\"master\"""",
-    """export GOOGLE_CLOUD_TESTING_BRANCH=\"main\"""",
-)
-
-s.replace(
-    "CONTRIBUTING.rst",
-    "remote \(``master``\)",
-    "remote (``main``)",
-)
-
-s.replace(
-    "CONTRIBUTING.rst",
-    "blob/master/CONTRIBUTING.rst",
-    "blob/main/CONTRIBUTING.rst",
-)
-
-s.replace(
-    "CONTRIBUTING.rst",
-    "blob/master/noxfile.py",
-    "blob/main/noxfile.py",
-)
-
-s.replace("docs/conf.py", "master", "root")
-
-# ----------------------------------------------------------------------------
 # Final cleanup
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR migrates from using a private post processor image `gcr.io/repo-automation-bots/owlbot-python:latest` to a public one `gcr.io/cloud-devrel-public-resources/owlbot-python:latest` which is used by automation to update templated files across python repositories in the googleapis org.

Use the following commands to test the feature:
```
# Pull the latest python post processor image `gcr.io/cloud-devrel-public-resources/owlbot-python`
docker pull gcr.io/cloud-devrel-public-resources/owlbot-python:latest
```

```
# Read the digest of the post processor image `gcr.io/cloud-devrel-public-resources/owlbot-python` with the tag `latest`
docker inspect --format='{{.RepoDigests}}' gcr.io/cloud-devrel-public-resources/owlbot-python:latest 
```

```
# In the root of the repo, use this command to run the public post processor image 
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo gcr.io/cloud-devrel-public-resources/owlbot-python:latest
```

The benefit is that external maintainers should now be able to run the post-processor locally and PRs should continue to be opened by automation when there are updates to templated files.

I tested the functionality in the python-datastream repository and it seems to be working correctly. If there is any issue , we can roll back to the private post processor image.

This PR also removes obsolete replacements in owlbot.py from the master->main branch migration.