### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ SQLAlchemy Dialect for BigQuery
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/sqlalchemy-bigquery.svg
    :target: https://pypi.org/project/sqlalchemy-bigquery/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/sqlalchemy-bigquery.svg


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.