### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,5 @@
     "distribution_name": "sqlalchemy-bigquery",
     "api_id": "bigquery.googleapis.com",
     "default_version": "",
-    "codeowner_team": ""
+    "codeowner_team": "@googleapis/api-bigquery"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,12 +1,13 @@
 {
-  "name": "sqlalchemy-bigquery",
-  "name_pretty": "SQLAlchemy dialect for BigQuery",
-  "client_documentation":
-    "https://googleapis.dev/python/sqlalchemy-bigquery/latest/index.html",
-  "release_level": "beta",
-  "language": "python",
-  "library_type": "INTEGRATION",
-  "repo": "googleapis/python-bigquery-sqlalchemy",
-  "distribution_name": "sqlalchemy-bigquery",
-  "api_id": "bigquery.googleapis.com"
+    "name": "sqlalchemy-bigquery",
+    "name_pretty": "SQLAlchemy dialect for BigQuery",
+    "client_documentation": "https://googleapis.dev/python/sqlalchemy-bigquery/latest/index.html",
+    "release_level": "beta",
+    "language": "python",
+    "library_type": "INTEGRATION",
+    "repo": "googleapis/python-bigquery-sqlalchemy",
+    "distribution_name": "sqlalchemy-bigquery",
+    "api_id": "bigquery.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
Set codeowner_team to @googleapis/api-bigquery as codeowner. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114
