### PR TITLE
fix: POSTCOMPILE expansion in SQLAlchemy 1.4.27+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/386
         # and
         # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/385
-        "sqlalchemy>=1.2.0,<=1.4.26",
+        "sqlalchemy>=1.2.0,<=1.4.27",
         "future",
     ],
     extras_require=extras,

--- a/sqlalchemy_bigquery/base.py
+++ b/sqlalchemy_bigquery/base.py
@@ -526,7 +526,7 @@ class BigQueryCompiler(_struct.SQLCompiler, SQLCompiler):
 
         assert_(param != "%s", f"Unexpected param: {param}")
 
-        if bindparam.expanding:
+        if bindparam.expanding:  # pragma: NO COVER
             assert_(self.__expanded_param(param), f"Unexpected param: {param}")
             if self.__sqlalchemy_version_info < (1, 4, 27):
                 param = param.replace(")", f":{bq_type})")

--- a/sqlalchemy_bigquery/base.py
+++ b/sqlalchemy_bigquery/base.py
@@ -341,16 +341,19 @@ class BigQueryCompiler(_struct.SQLCompiler, SQLCompiler):
 
     __sqlalchemy_version_info = tuple(map(int, sqlalchemy.__version__.split(".")))
 
-    __expandng_text = (
+    __expanding_text = (
         "EXPANDING" if __sqlalchemy_version_info < (1, 4) else "POSTCOMPILE"
     )
+
+    # https://github.com/sqlalchemy/sqlalchemy/commit/f79df12bd6d99b8f6f09d4bf07722638c4b4c159
+    __expanding_conflict = "" if __sqlalchemy_version_info < (1, 4, 27) else "__"
 
     __in_expanding_bind = _helpers.substitute_string_re_method(
         fr"""
         \sIN\s\(                     # ' IN ('
         (
-        \[                           # Expanding placeholder
-        {__expandng_text}            #   e.g. [EXPANDING_foo_1]
+        {__expanding_conflict}\[     # Expanding placeholder
+        {__expanding_text}           #   e.g. [EXPANDING_foo_1]
         _[^\]]+                      #
         \]
         (:[A-Z0-9]+)?                # type marker (e.g. ':INT64'
@@ -431,7 +434,9 @@ class BigQueryCompiler(_struct.SQLCompiler, SQLCompiler):
 
     __placeholder = re.compile(r"%\(([^\]:]+)(:[^\]:]+)?\)s$").match
 
-    __expanded_param = re.compile(fr"\(\[" fr"{__expandng_text}" fr"_[^\]]+\]\)$").match
+    __expanded_param = re.compile(
+        fr"\({__expanding_conflict}\[" fr"{__expanding_text}" fr"_[^\]]+\]\)$"
+    ).match
 
     __remove_type_parameter = _helpers.substitute_string_re_method(
         r"""

--- a/sqlalchemy_bigquery/base.py
+++ b/sqlalchemy_bigquery/base.py
@@ -528,7 +528,8 @@ class BigQueryCompiler(_struct.SQLCompiler, SQLCompiler):
 
         if bindparam.expanding:
             assert_(self.__expanded_param(param), f"Unexpected param: {param}")
-            param = param.replace(")", f":{bq_type})")
+            if self.__sqlalchemy_version_info < (1, 4, 27):
+                param = param.replace(")", f":{bq_type})")
 
         else:
             m = self.__placeholder(param)


### PR DESCRIPTION
Handle the new double underscore prefix for POSTCOMPILE variables introduced in SQLAlchemy 1.4.27 onwards. (See commit [sqlalchemy#f79df12bd6d99b8f6f09d4bf07722638c4b4c159](https://github.com/sqlalchemy/sqlalchemy/commit/f79df12bd6d99b8f6f09d4bf07722638c4b4c159))

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-sqlalchemy/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Related to #385 🦕

Actually encountered this issue in `pybigquery` (dependency for [great_expectations](https://greatexpectations.io/)), not sure if there's a backporting process or if that's just completely unsupported now?
