### PR TITLE
fix: use faux_conn rather than engine in unit tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -43,11 +43,6 @@ sqlalchemy_before_1_4 = pytest.mark.skipif(
 
 
 @pytest.fixture()
-def engine():
-    return sqlalchemy.create_engine("bigquery://myproject/mydataset")
-
-
-@pytest.fixture()
 def faux_conn():
     test_data = dict(execute=[])
     connection = sqlite3.connect(":memory:")

--- a/tests/unit/test__struct.py
+++ b/tests/unit/test__struct.py
@@ -80,9 +80,9 @@ def _col():
         ),
     ],
 )
-def test_struct_traversal_project(engine, expr, sql):
+def test_struct_traversal_project(faux_conn, expr, sql):
     sql = f"SELECT {sql} AS `anon_1` \nFROM `t`"
-    assert str(sqlalchemy.select([expr]).compile(engine)) == sql
+    assert str(sqlalchemy.select([expr]).compile(faux_conn.engine)) == sql
 
 
 @pytest.mark.parametrize(
@@ -113,13 +113,13 @@ def test_struct_traversal_project(engine, expr, sql):
         ),
     ],
 )
-def test_struct_traversal_filter(engine, expr, sql, param=1):
+def test_struct_traversal_filter(faux_conn, expr, sql, param=1):
     want = f"SELECT `t`.`person` \nFROM `t`, `t` \nWHERE {sql}"
-    got = str(sqlalchemy.select([_col()]).where(expr).compile(engine))
+    got = str(sqlalchemy.select([_col()]).where(expr).compile(faux_conn.engine))
     assert got == want
 
 
-def test_struct_insert_type_info(engine, metadata):
+def test_struct_insert_type_info(faux_conn, metadata):
     t = sqlalchemy.Table("t", metadata, sqlalchemy.Column("person", _test_struct()))
     got = str(
         t.insert()
@@ -129,7 +129,7 @@ def test_struct_insert_type_info(engine, metadata):
                 children=[dict(name="billy", bdate=datetime.date(2020, 1, 1))],
             )
         )
-        .compile(engine)
+        .compile(faux_conn.engine)
     )
 
     assert got == (
@@ -139,7 +139,7 @@ def test_struct_insert_type_info(engine, metadata):
     )
 
 
-def test_struct_non_string_field_access(engine):
+def test_struct_non_string_field_access(faux_conn):
     with pytest.raises(
         TypeError,
         match="STRUCT fields can only be accessed with strings field names, not 42",
@@ -147,6 +147,6 @@ def test_struct_non_string_field_access(engine):
         _col()[42]
 
 
-def test_struct_bad_name(engine):
+def test_struct_bad_name(faux_conn):
     with pytest.raises(KeyError, match="42"):
         _col()["42"]

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -433,9 +433,9 @@ def test_unnest_w_no_table_references(faux_conn, alias):
     )
 
 
-def test_array_indexing(engine, metadata):
+def test_array_indexing(faux_conn, metadata):
     t = sqlalchemy.Table(
         "t", metadata, sqlalchemy.Column("a", sqlalchemy.ARRAY(sqlalchemy.String)),
     )
-    got = str(sqlalchemy.select([t.c.a[0]]).compile(engine))
+    got = str(sqlalchemy.select([t.c.a[0]]).compile(faux_conn.engine))
     assert got == "SELECT `t`.`a`[OFFSET(%(a_1:INT64)s)] AS `anon_1` \nFROM `t`"


### PR DESCRIPTION
Remove the engine fixture from unit tests and use faux_conn instead. Creating
an engine requires credentials, which prevents these tests from being pure unit
tests and running in any environment.

Fixes #430 🦕
