### PR TITLE
chore: use pytest-flake8==1.1.0 in dev_requirements.txt

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,5 +2,5 @@ sqlalchemy>=1.1.9
 google-cloud-bigquery>=1.6.0
 future==0.18.2
 pytest==6.2.5
-pytest-flake8==1.1.1
+pytest-flake8==1.1.0  # versions 1.1.1 and above require pytest 7
 pytz==2022.1


### PR DESCRIPTION
#### Summary

`dev_requirements.txt` was recently changed to upgrade the dependency on pytest-flake8 from 1.1.0 to 1.1.1. Unfortunately, pytest-flake8 requires pytest 7 or above, and the current pinned dependency for pytest is 6.2.5. I tried moving up to pytest 7 but it seems like there's a decent amount of work going into that, so in order to fix main, this PR moves the pytest-flake8 pinned version back to 1.1.0.

Fixes #445.
