### PR TITLE
Remove pyarrow from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
         "google-auth>=1.25.0,<3.0.0dev",  # Work around pip wack.
         "google-cloud-bigquery>=2.25.2,<4.0.0dev",
         "google-cloud-bigquery-storage>=2.0.0,<3.0.0dev",
-        "pyarrow>=3.0.0,<7.0dev",
         # Temporarily set maximimum sqlalchemy to a known-working version while
         # we debug failing compliance tests. See:
         # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/386


### PR DESCRIPTION
#414 added `pyarrow` to the `setup.py` as part of adding `google-bigquery-storage` to `install_requires`. I understand the motivation for adding `google-bigquery-storage`, but since that has its own allowed `pyarrow` version range, it seems simpler to just rely on that rather than specifying yet another `pyarrow` range here which can get (/ currently is) out of sync with that library.

@tswast what do you think?