### PR TITLE
fix: Sets cache support to false, removes upper req limit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,11 +86,6 @@ setup(
         "google-cloud-bigquery>=2.25.2,<4.0.0dev",
         "google-cloud-bigquery-storage>=2.0.0,<3.0.0dev",
         "pyarrow>=3.0.0,<7.0dev",
-        # Temporarily set maximimum sqlalchemy to a known-working version while
-        # we debug failing compliance tests. See:
-        # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/386
-        # and
-        # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/385
         "sqlalchemy>=1.2.0",
         "future",
     ],

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/386
         # and
         # https://github.com/googleapis/python-bigquery-sqlalchemy/issues/385
-        "sqlalchemy>=1.2.0,<=1.4.27",
+        "sqlalchemy>=1.2.0",
         "future",
     ],
     extras_require=extras,

--- a/sqlalchemy_bigquery/base.py
+++ b/sqlalchemy_bigquery/base.py
@@ -733,6 +733,7 @@ class BigQueryDialect(DefaultDialect):
     supports_default_values = False
     supports_empty_insert = False
     supports_multivalues_insert = True
+    supports_statement_cache = False
     supports_unicode_statements = True
     supports_unicode_binds = True
     supports_native_decimal = True


### PR DESCRIPTION
This PR does two things:

* Updates the upper bound on requirements for python-bigquery-sqlalchemy
* Sets the status of the BigQueryDialect attribute `supports_statement_cache` to `False`

At this time, it is not yet clear whether BigQuery, out of the box, supports SQL statement caching. In an effort to clear the failing tests and allow interoperability with sqlalchemy > 1.4.27, we are opting to provide these limited changes while additional work is pursued to confirm that BigQuery connector libraries and APIs support statement caching.

Fixes #385 🦕

A follow on issue (**TODO: add issue number here**), will be submitted prior to closing this PR to ensure that resources are applied to confirming statement caching support.

**TODO** add a comment to the code regarding the `supports_statement_cache = False` purpose and next steps.