### PR TITLE
fix: remove type annotations from _struct.py

### DIFF
--- a/sqlalchemy_bigquery/_struct.py
+++ b/sqlalchemy_bigquery/_struct.py
@@ -54,8 +54,8 @@ class STRUCT(sqlalchemy.sql.sqltypes.Indexable, sqlalchemy.types.UserDefinedType
 
     def __init__(
         self,
-        *fields: Tuple[str, sqlalchemy.types.TypeEngine],
-        **kwfields: Mapping[str, sqlalchemy.types.TypeEngine],
+        *fields,
+        **kwfields,
     ):
         # Note that because:
         # https://docs.python.org/3/whatsnew/3.6.html#pep-468-preserving-keyword-argument-order


### PR DESCRIPTION
Removes type annotations from `_struct.py`
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-sqlalchemy/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #545  🦕
