### PR TITLE
fix: Adds keyword argument to test due to changes in sqlalchemy alembic

### DIFF
--- a/tests/system/test_alembic.py
+++ b/tests/system/test_alembic.py
@@ -149,9 +149,7 @@ def test_alembic_scenario(alembic_table):
         """
     )
 
-    # One thing we can alter about a column is we can make it
-    # nullable:
-    op.alter_column("transactions", "amount", True)
+    op.alter_column("transactions", "amount", nullable=True)
     assert alembic_table("transactions", "schema") == [
         SchemaField("account", "INTEGER", "REQUIRED"),
         SchemaField("transaction_time", "DATETIME", "REQUIRED"),


### PR DESCRIPTION
`sqlalchemy-alembic` changed the function signature for a [number of functions](https://github.com/sqlalchemy/alembic/commit/df75e85489b9ae69fffff2c5ad2594b30bed2fd4):

They added an asterisk (`*`) into the function signature to separate positional arguments from keyword arguments. 

This has the downstream effect of requiring keyword arguments to be spelled out when calling them within the function. This affected one of our tests, since none of the other tests specifically used any keyword arguments.

Based on a check through the code for other uses of functions from alembic, none of our other uses of the functions in either the body of the code OR in our tests appears to be impacted by the upstream change.

Fixes #862 🦕
