### PR TITLE
test: corrects a defect in the data supplied to a test

### DIFF
--- a/tests/unit/test_geography.py
+++ b/tests/unit/test_geography.py
@@ -159,6 +159,7 @@ def test_GEOGRAPHY_ElementType_bad_extended():
 
 def test_GEOGRAPHY_ElementType():
     from sqlalchemy_bigquery import GEOGRAPHY, WKB
+
     # The data argument here should be composed of hex characters:
     # 1-0 and a-f
     data = GEOGRAPHY.ElementType("123def")

--- a/tests/unit/test_geography.py
+++ b/tests/unit/test_geography.py
@@ -159,10 +159,11 @@ def test_GEOGRAPHY_ElementType_bad_extended():
 
 def test_GEOGRAPHY_ElementType():
     from sqlalchemy_bigquery import GEOGRAPHY, WKB
-
-    data = GEOGRAPHY.ElementType("data")
+    # The data argument here should be composed of hex characters:
+    # 1-0 and a-f
+    data = GEOGRAPHY.ElementType("123def")
     assert isinstance(data, WKB)
-    assert (data.data, data.srid, data.extended) == ("data", 4326, True)
+    assert (data.data, data.srid, data.extended) == ("123def", 4326, True)
 
 
 def test_calling_st_functions_that_dont_take_geographies(faux_conn, last_query):


### PR DESCRIPTION
In version 3.9 of Python (and potentially other later versions) when running the tests, one of the tests was failing.

It appears that in some of the processing in one of the dependencies, the data that is supplied to our tests was incorrect. It included characters that were not HEX characters: i.e. the `t` in the string `data`.

This replaces the string `data` with the string `123def`. 

Fixes #875 
