### PR TITLE
fix: removing Python 3.7 from sync-repo-settings.yaml file

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -11,7 +11,6 @@ branchProtectionRules:
     - 'OwlBot Post Processor'
     - 'Kokoro'
     - 'Samples - Lint'
-    - 'Samples - Python 3.7'
     - 'Samples - Python 3.8'
     - 'Samples - Python 3.9'
     - 'Samples - Python 3.10'


### PR DESCRIPTION
Python 3.7 is a required check set by in the [config file](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Fgoogleapis%2Fpython-bigquery-sqlalchemy%2Fblob%2Fmain%2F.github%2Fsync-repo-settings.yaml). Python 3.7 needs to be removed from .github/sync-repo-settings.yaml before being removed in g3.
