### PR TITLE
test: prevent alchemy test suite from being rate-limited.

### DIFF
--- a/tests/system/test_alembic.py
+++ b/tests/system/test_alembic.py
@@ -107,6 +107,18 @@ def test_alembic_scenario(alembic_table):
         SchemaField("last_transaction_date", "DATETIME", description="when updated"),
     ]
 
+    op.rename_table("account", "accounts")
+    assert alembic_table("account") is None
+    assert alembic_table("accounts", "schema") == [
+        SchemaField("id", "INTEGER", "REQUIRED"),
+        SchemaField("name", "STRING(50)", "REQUIRED", description="The name"),
+        SchemaField("description", "STRING(200)"),
+        SchemaField("last_transaction_date", "DATETIME", description="when updated"),
+    ]
+
+    op.drop_table("accounts")
+    assert alembic_table("accounts") is None
+
     op.create_table(
         "account_w_comment",
         Column("id", Integer, nullable=False),
@@ -126,17 +138,6 @@ def test_alembic_scenario(alembic_table):
 
     op.drop_table("account_w_comment")
     assert alembic_table("account_w_comment") is None
-
-    op.rename_table("account", "accounts")
-    assert alembic_table("account") is None
-    assert alembic_table("accounts", "schema") == [
-        SchemaField("id", "INTEGER", "REQUIRED"),
-        SchemaField("name", "STRING(50)", "REQUIRED", description="The name"),
-        SchemaField("description", "STRING(200)"),
-        SchemaField("last_transaction_date", "DATETIME", description="when updated"),
-    ]
-    op.drop_table("accounts")
-    assert alembic_table("accounts") is None
 
     op.create_table(
         "transactions",


### PR DESCRIPTION
Checking the error message in the Kokoro Prerelease Dependencies check in https://github.com/googleapis/python-bigquery-sqlalchemy/pull/936, it appears that the alembic system test suite is beeing rate-limited after exceeding the DDL operations quota (https://cloud.google.com/bigquery/quotas#standard_tables).

I suggest we could add a delay to prevent the test from being rate-limited. This is not very elegant but it should not have too much impacts on the overall delay of the test suite.

We could also introduce a more relevant retry-strategy that would requires some more work.

----

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-sqlalchemy/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
