### PR TITLE
Revert "chore: cleanup compliance tests for sqlalchemy migration"

### DIFF
--- a/sqlalchemy_bigquery/_struct.py
+++ b/sqlalchemy_bigquery/_struct.py
@@ -17,14 +17,20 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import packaging.version
 import sqlalchemy.sql.default_comparator
 import sqlalchemy.sql.sqltypes
 import sqlalchemy.types
 
 from . import base
 
-import sqlalchemy.sql.coercions
-import sqlalchemy.sql.roles
+sqlalchemy_1_4_or_more = packaging.version.parse(
+    sqlalchemy.__version__
+) >= packaging.version.parse("1.4")
+
+if sqlalchemy_1_4_or_more:
+    import sqlalchemy.sql.coercions
+    import sqlalchemy.sql.roles
 
 
 def _get_subtype_col_spec(type_):
@@ -103,14 +109,30 @@ class STRUCT(sqlalchemy.sql.sqltypes.Indexable, sqlalchemy.types.UserDefinedType
     comparator_factory = Comparator
 
 
-def _field_index(self, name, operator):
-    return sqlalchemy.sql.coercions.expect(
-        sqlalchemy.sql.roles.BinaryElementRole,
-        name,
-        expr=self.expr,
-        operator=operator,
-        bindparam_type=sqlalchemy.types.String(),
-    )
+# In the implementations of _field_index below, we're stealing from
+# the JSON type implementation, but the code to steal changed in
+# 1.4. :/
+
+if sqlalchemy_1_4_or_more:
+
+    def _field_index(self, name, operator):
+        return sqlalchemy.sql.coercions.expect(
+            sqlalchemy.sql.roles.BinaryElementRole,
+            name,
+            expr=self.expr,
+            operator=operator,
+            bindparam_type=sqlalchemy.types.String(),
+        )
+
+else:
+
+    def _field_index(self, name, operator):
+        return sqlalchemy.sql.default_comparator._check_literal(
+            self.expr,
+            operator,
+            name,
+            bindparam_type=sqlalchemy.types.String(),
+        )
 
 
 def struct_getitem_op(a, b):

--- a/sqlalchemy_bigquery/base.py
+++ b/sqlalchemy_bigquery/base.py
@@ -163,7 +163,7 @@ class BigQueryExecutionContext(DefaultExecutionContext):
         """,
         flags=re.IGNORECASE | re.VERBOSE,
     )
-    def __distribute_types_to_expanded_placeholders(self, m):  # pragma: NO COVER
+    def __distribute_types_to_expanded_placeholders(self, m):
         # If we have an in parameter, it sometimes gets expaned to 0 or more
         # parameters and we need to move the type marker to each
         # parameter.
@@ -174,8 +174,6 @@ class BigQueryExecutionContext(DefaultExecutionContext):
         # suffixes refect that when an array parameter is expanded,
         # numeric suffixes are added.  For example, a placeholder like
         # `%(foo)s` gets expaneded to `%(foo_0)s, `%(foo_1)s, ...`.
-
-        # Coverage: despite our best efforts, never recognized this segment of code as being tested.
         placeholders, type_ = m.groups()
         if placeholders:
             placeholders = placeholders.replace(")", f":{type_})")
@@ -358,7 +356,11 @@ class BigQueryCompiler(_struct.SQLCompiler, SQLCompiler):
 
     __sqlalchemy_version_info = packaging.version.parse(sqlalchemy.__version__)
 
-    __expanding_text = "POSTCOMPILE"
+    __expanding_text = (
+        "EXPANDING"
+        if __sqlalchemy_version_info < packaging.version.parse("1.4")
+        else "POSTCOMPILE"
+    )
 
     # https://github.com/sqlalchemy/sqlalchemy/commit/f79df12bd6d99b8f6f09d4bf07722638c4b4c159
     __expanding_conflict = (
@@ -385,6 +387,9 @@ class BigQueryCompiler(_struct.SQLCompiler, SQLCompiler):
         return self.__in_expanding_bind(
             self._generate_generic_binary(binary, " IN ", **kw)
         )
+
+    def visit_empty_set_expr(self, element_types, **kw):
+        return ""
 
     def visit_not_in_op_binary(self, binary, operator, **kw):
         return (
@@ -419,13 +424,28 @@ class BigQueryCompiler(_struct.SQLCompiler, SQLCompiler):
             self._maybe_reescape(binary), operator, **kw
         )
 
+    def visit_notcontains_op_binary(self, binary, operator, **kw):
+        return super(BigQueryCompiler, self).visit_notcontains_op_binary(
+            self._maybe_reescape(binary), operator, **kw
+        )
+
     def visit_startswith_op_binary(self, binary, operator, **kw):
         return super(BigQueryCompiler, self).visit_startswith_op_binary(
             self._maybe_reescape(binary), operator, **kw
         )
 
+    def visit_notstartswith_op_binary(self, binary, operator, **kw):
+        return super(BigQueryCompiler, self).visit_notstartswith_op_binary(
+            self._maybe_reescape(binary), operator, **kw
+        )
+
     def visit_endswith_op_binary(self, binary, operator, **kw):
         return super(BigQueryCompiler, self).visit_endswith_op_binary(
+            self._maybe_reescape(binary), operator, **kw
+        )
+
+    def visit_notendswith_op_binary(self, binary, operator, **kw):
+        return super(BigQueryCompiler, self).visit_notendswith_op_binary(
             self._maybe_reescape(binary), operator, **kw
         )
 
@@ -490,8 +510,7 @@ class BigQueryCompiler(_struct.SQLCompiler, SQLCompiler):
             # here, because then we can't do a recompile later (e.g., first
             # print the statment, then execute it).  See issue #357.
             #
-            # Coverage: despite our best efforts, never recognized this segment of code as being tested.
-            if getattr(bindparam, "expand_op", None) is not None:  # pragma: NO COVER
+            if getattr(bindparam, "expand_op", None) is not None:
                 assert bindparam.expand_op.__name__.endswith("in_op")  # in in
                 bindparam = bindparam._clone(maintain_key=True)
                 bindparam.expanding = False
@@ -1258,6 +1277,10 @@ class BigQueryDialect(DefaultDialect):
     def do_rollback(self, dbapi_connection):
         # BigQuery has no support for transactions.
         pass
+
+    def _check_unicode_returns(self, connection, additional_tests=None):
+        # requests gives back Unicode strings
+        return True
 
     def get_view_definition(self, connection, view_name, schema=None, **kw):
         if isinstance(connection, Engine):

--- a/sqlalchemy_bigquery/requirements.py
+++ b/sqlalchemy_bigquery/requirements.py
@@ -24,6 +24,7 @@ based on database capabilities.
 
 import sqlalchemy.testing.requirements
 import sqlalchemy.testing.exclusions
+from sqlalchemy.testing.exclusions import against, only_on
 
 supported = sqlalchemy.testing.exclusions.open
 unsupported = sqlalchemy.testing.exclusions.closed

--- a/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
+++ b/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
@@ -29,21 +29,18 @@ from sqlalchemy import and_
 import sqlalchemy.testing.suite.test_types
 import sqlalchemy.sql.sqltypes
 from sqlalchemy.testing import util, config
+from sqlalchemy.testing import is_false
+from sqlalchemy.testing import is_true
+from sqlalchemy.testing import is_
 from sqlalchemy.testing.assertions import eq_
-from sqlalchemy.testing.suite import select, exists
+from sqlalchemy.testing.suite import config, select, exists
 from sqlalchemy.testing.suite import *  # noqa
-from sqlalchemy.testing.suite import Integer, Table, Column, String, bindparam, testing
 from sqlalchemy.testing.suite import (
+    ComponentReflectionTest as _ComponentReflectionTest,
     CTETest as _CTETest,
     ExistsTest as _ExistsTest,
-    FetchLimitOffsetTest as _FetchLimitOffsetTest,
-    DifficultParametersTest as _DifficultParametersTest,
-    DistinctOnTest,
-    HasIndexTest,
-    IdentityAutoincrementTest,
     InsertBehaviorTest as _InsertBehaviorTest,
     LongNameBlowoutTest,
-    PostCompileParamsTest,
     QuotedNameArgumentTest,
     SimpleUpdateDeleteTest as _SimpleUpdateDeleteTest,
     TimestampMicrosecondsTest as _TimestampMicrosecondsTest,
@@ -56,23 +53,156 @@ from sqlalchemy.testing.suite.test_types import (
 from sqlalchemy.testing.suite.test_reflection import (
     BizarroCharacterFKResolutionTest,
     ComponentReflectionTest,
+    OneConnectionTablesTest,
     HasTableTest,
 )
 
 if packaging.version.parse(sqlalchemy.__version__) >= packaging.version.parse("2.0"):
     import uuid
     from sqlalchemy.sql import type_coerce
+    from sqlalchemy import Uuid
     from sqlalchemy.testing.suite import (
         TrueDivTest as _TrueDivTest,
         IntegerTest as _IntegerTest,
         NumericTest as _NumericTest,
+        DifficultParametersTest as _DifficultParametersTest,
+        FetchLimitOffsetTest as _FetchLimitOffsetTest,
+        PostCompileParamsTest,
         StringTest as _StringTest,
         UuidTest as _UuidTest,
     )
 
-    class DifficultParametersTest(_DifficultParametersTest):
-        """There are some parameters that don't work with bigquery that were removed from this test"""
+    class TimestampMicrosecondsTest(_TimestampMicrosecondsTest):
+        data = datetime.datetime(2012, 10, 15, 12, 57, 18, 396, tzinfo=pytz.UTC)
 
+        def test_select_direct(self, connection):
+            # This func added because this test was failing when passed the
+            # UTC timezone.
+
+            def literal(value, type_=None):
+                assert value == self.data
+
+                if type_ is not None:
+                    assert type_ is self.datatype
+
+                return sqlalchemy.sql.elements.literal(value, self.datatype)
+
+            with mock.patch("sqlalchemy.testing.suite.test_types.literal", literal):
+                super(TimestampMicrosecondsTest, self).test_select_direct(connection)
+
+    def test_round_trip_executemany(self, connection):
+        unicode_table = self.tables.unicode_table
+        connection.execute(
+            unicode_table.insert(),
+            [{"id": i, "unicode_data": self.data} for i in range(3)],
+        )
+
+        rows = connection.execute(select(unicode_table.c.unicode_data)).fetchall()
+        eq_(rows, [(self.data,) for i in range(3)])
+        for row in rows:
+            # 2.0 had no support for util.text_type
+            assert isinstance(row[0], str)
+
+    sqlalchemy.testing.suite.test_types._UnicodeFixture.test_round_trip_executemany = (
+        test_round_trip_executemany
+    )
+
+    class TrueDivTest(_TrueDivTest):
+        @pytest.mark.skip("BQ rounds based on datatype")
+        def test_floordiv_integer(self):
+            pass
+
+        @pytest.mark.skip("BQ rounds based on datatype")
+        def test_floordiv_integer_bound(self):
+            pass
+
+    class SimpleUpdateDeleteTest(_SimpleUpdateDeleteTest):
+        """The base tests fail if operations return rows for some reason."""
+
+        def test_update(self):
+            t = self.tables.plain_pk
+            connection = config.db.connect()
+            # In SQLAlchemy 2.0, the datatype changed to dict in the following function.
+            r = connection.execute(t.update().where(t.c.id == 2), dict(data="d2_new"))
+            assert not r.is_insert
+
+            eq_(
+                connection.execute(t.select().order_by(t.c.id)).fetchall(),
+                [(1, "d1"), (2, "d2_new"), (3, "d3")],
+            )
+
+        def test_delete(self):
+            t = self.tables.plain_pk
+            connection = config.db.connect()
+            r = connection.execute(t.delete().where(t.c.id == 2))
+            assert not r.is_insert
+            eq_(
+                connection.execute(t.select().order_by(t.c.id)).fetchall(),
+                [(1, "d1"), (3, "d3")],
+            )
+
+    class InsertBehaviorTest(_InsertBehaviorTest):
+        @pytest.mark.skip(
+            "BQ has no autoinc and client-side defaults can't work for select."
+        )
+        def test_insert_from_select_autoinc(cls):
+            pass
+
+        @pytest.mark.skip(
+            "BQ has no autoinc and client-side defaults can't work for select."
+        )
+        def test_no_results_for_non_returning_insert(cls):
+            pass
+
+    # BQ has no autoinc and client-side defaults can't work for select
+    del _IntegerTest.test_huge_int_auto_accommodation
+
+    class NumericTest(_NumericTest):
+        @testing.fixture
+        def do_numeric_test(self, metadata, connection):
+            def run(type_, input_, output, filter_=None, check_scale=False):
+                t = Table("t", metadata, Column("x", type_))
+                t.create(connection)
+                connection.execute(t.insert(), [{"x": x} for x in input_])
+
+                result = {row[0] for row in connection.execute(t.select())}
+                output = set(output)
+                if filter_:
+                    result = {filter_(x) for x in result}
+                    output = {filter_(x) for x in output}
+                eq_(result, output)
+                if check_scale:
+                    eq_([str(x) for x in result], [str(x) for x in output])
+
+                where_expr = True
+
+                # Adding where clause for 2.0 compatibility
+                connection.execute(t.delete().where(where_expr))
+
+                # test that this is actually a number!
+                # note we have tiny scale here as we have tests with very
+                # small scale Numeric types.  PostgreSQL will raise an error
+                # if you use values outside the available scale.
+                if type_.asdecimal:
+                    test_value = decimal.Decimal("2.9")
+                    add_value = decimal.Decimal("37.12")
+                else:
+                    test_value = 2.9
+                    add_value = 37.12
+
+                connection.execute(t.insert(), {"x": test_value})
+                assert_we_are_a_number = connection.scalar(
+                    select(type_coerce(t.c.x + add_value, type_))
+                )
+                eq_(
+                    round(assert_we_are_a_number, 3),
+                    round(test_value + add_value, 3),
+                )
+
+            return run
+
+    class DifficultParametersTest(_DifficultParametersTest):
+        # removed parameters that dont work with bigquery
         tough_parameters = testing.combinations(
             ("boring",),
             ("per cent",),
@@ -177,149 +307,34 @@ if packaging.version.parse(sqlalchemy.__version__) >= packaging.version.parse("2
             res = connection.scalars(stmt, {paramname: ["d", "a"]}).all()
             eq_(res, [1, 4])
 
-    # BQ has no autoinc and client-side defaults can't work for select
-    del _IntegerTest.test_huge_int_auto_accommodation
-
-    class NumericTest(_NumericTest):
-        """Added a where clause for BQ compatibility."""
-
-        @testing.fixture
-        def do_numeric_test(self, metadata, connection):
-            def run(type_, input_, output, filter_=None, check_scale=False):
-                t = Table("t", metadata, Column("x", type_))
-                t.create(connection)
-                connection.execute(t.insert(), [{"x": x} for x in input_])
-
-                result = {row[0] for row in connection.execute(t.select())}
-                output = set(output)
-                if filter_:
-                    result = {filter_(x) for x in result}
-                    output = {filter_(x) for x in output}
-                eq_(result, output)
-                if check_scale:
-                    eq_([str(x) for x in result], [str(x) for x in output])
-
-                where_expr = True
-
-                connection.execute(t.delete().where(where_expr))
-
-                if type_.asdecimal:
-                    test_value = decimal.Decimal("2.9")
-                    add_value = decimal.Decimal("37.12")
-                else:
-                    test_value = 2.9
-                    add_value = 37.12
-
-                connection.execute(t.insert(), {"x": test_value})
-                assert_we_are_a_number = connection.scalar(
-                    select(type_coerce(t.c.x + add_value, type_))
-                )
-                eq_(
-                    round(assert_we_are_a_number, 3),
-                    round(test_value + add_value, 3),
-                )
-
-            return run
-
-    class TimestampMicrosecondsTest(_TimestampMicrosecondsTest):
-        """BQ has no support for BQ util.text_type"""
-
-        data = datetime.datetime(2012, 10, 15, 12, 57, 18, 396, tzinfo=pytz.UTC)
-
-        def test_select_direct(self, connection):
-            # This func added because this test was failing when passed the
-            # UTC timezone.
-
-            def literal(value, type_=None):
-                assert value == self.data
-
-                if type_ is not None:
-                    assert type_ is self.datatype
-
-                return sqlalchemy.sql.elements.literal(value, self.datatype)
-
-            with mock.patch("sqlalchemy.testing.suite.test_types.literal", literal):
-                super(TimestampMicrosecondsTest, self).test_select_direct(connection)
-
-    def test_round_trip_executemany(self, connection):
-        unicode_table = self.tables.unicode_table
-        connection.execute(
-            unicode_table.insert(),
-            [{"id": i, "unicode_data": self.data} for i in range(3)],
-        )
-
-        rows = connection.execute(select(unicode_table.c.unicode_data)).fetchall()
-        eq_(rows, [(self.data,) for i in range(3)])
-        for row in rows:
-            assert isinstance(row[0], str)
-
-    sqlalchemy.testing.suite.test_types._UnicodeFixture.test_round_trip_executemany = (
-        test_round_trip_executemany
-    )
-
-    class TrueDivTest(_TrueDivTest):
-        @pytest.mark.skip("BQ rounds based on datatype")
-        def test_floordiv_integer(self):
+    class FetchLimitOffsetTest(_FetchLimitOffsetTest):
+        @pytest.mark.skip("BigQuery doesn't allow an offset without a limit.")
+        def test_simple_offset(self):
             pass
 
-        @pytest.mark.skip("BQ rounds based on datatype")
-        def test_floordiv_integer_bound(self):
-            pass
+        test_bound_offset = test_simple_offset
+        test_expr_offset = test_simple_offset_zero = test_simple_offset
+        test_limit_offset_nobinds = test_simple_offset  # TODO figure out
+        # how to prevent this from failing
+        # The original test is missing an order by.
 
-    class SimpleUpdateDeleteTest(_SimpleUpdateDeleteTest):
-        """The base tests fail if operations return rows for some reason."""
+        # The original test is missing an order by.
 
-        def test_update(self):
-            t = self.tables.plain_pk
-            connection = config.db.connect()
-            # In SQLAlchemy 2.0, the datatype changed to dict in the following function.
-            r = connection.execute(t.update().where(t.c.id == 2), dict(data="d2_new"))
-            assert not r.is_insert
+        # Also, note that sqlalchemy union is a union distinct, not a
+        # union all. This test caught that were were getting that wrong.
+        def test_limit_render_multiple_times(self, connection):
+            table = self.tables.some_table
+            stmt = select(table.c.id).order_by(table.c.id).limit(1).scalar_subquery()
 
-            eq_(
-                connection.execute(t.select().order_by(t.c.id)).fetchall(),
-                [(1, "d1"), (2, "d2_new"), (3, "d3")],
+            u = sqlalchemy.union(select(stmt), select(stmt)).subquery().select()
+
+            self._assert_result(
+                connection,
+                u,
+                [(1,)],
             )
-
-        def test_delete(self):
-            t = self.tables.plain_pk
-            connection = config.db.connect()
-            r = connection.execute(t.delete().where(t.c.id == 2))
-            assert not r.is_insert
-            eq_(
-                connection.execute(t.select().order_by(t.c.id)).fetchall(),
-                [(1, "d1"), (3, "d3")],
-            )
-
-    class StringTest(_StringTest):
-        """Added a where clause for BQ compatibility"""
-
-        def test_dont_truncate_rightside(
-            self, metadata, connection, expr=None, expected=None
-        ):
-            t = Table(
-                "t",
-                metadata,
-                Column("x", String(2)),
-                Column("id", Integer, primary_key=True),
-            )
-            t.create(connection)
-            connection.connection.commit()
-            connection.execute(
-                t.insert(),
-                [{"x": "AB", "id": 1}, {"x": "BC", "id": 2}, {"x": "AC", "id": 3}],
-            )
-            combinations = [("%B%", ["AB", "BC"]), ("A%C", ["AC"]), ("A%C%Z", [])]
-
-            for args in combinations:
-                eq_(
-                    connection.scalars(select(t.c.x).where(t.c.x.like(args[0]))).all(),
-                    args[1],
-                )
 
     class UuidTest(_UuidTest):
-        """BQ needs to pass in UUID as a string"""
-
         @classmethod
         def define_tables(cls, metadata):
             Table(
@@ -424,38 +439,81 @@ if packaging.version.parse(sqlalchemy.__version__) >= packaging.version.parse("2
 
             eq_(row, (data, str_data, data, str_data))
 
-else:
-    from sqlalchemy.testing.suite import (
-        RowCountTest as _RowCountTest,
-    )
-
-    del DifficultParametersTest  # exercises column names illegal in BQ
-
-    class RowCountTest(_RowCountTest):
-        """"""
-
-        @classmethod
-        def insert_data(cls, connection):
-            cls.data = data = [
-                ("Angela", "A"),
-                ("Andrew", "A"),
-                ("Anand", "A"),
-                ("Bob", "B"),
-                ("Bobette", "B"),
-                ("Buffy", "B"),
-                ("Charlie", "C"),
-                ("Cynthia", "C"),
-                ("Chris", "C"),
-            ]
-
-            employees_table = cls.tables.employees
-            connection.execute(
-                employees_table.insert(),
-                [
-                    {"employee_id": i, "name": n, "department": d}
-                    for i, (n, d) in enumerate(data)
-                ],
+    class StringTest(_StringTest):
+        def test_dont_truncate_rightside(
+            self, metadata, connection, expr=None, expected=None
+        ):
+            t = Table(
+                "t",
+                metadata,
+                Column("x", String(2)),
+                Column("id", Integer, primary_key=True),
             )
+            t.create(connection)
+            connection.connection.commit()
+            connection.execute(
+                t.insert(),
+                [{"x": "AB", "id": 1}, {"x": "BC", "id": 2}, {"x": "AC", "id": 3}],
+            )
+            combinations = [("%B%", ["AB", "BC"]), ("A%C", ["AC"]), ("A%C%Z", [])]
+
+            for args in combinations:
+                eq_(
+                    connection.scalars(select(t.c.x).where(t.c.x.like(args[0]))).all(),
+                    args[1],
+                )
+
+    # from else statement ....
+    del DistinctOnTest  # expects unquoted table names.
+    del HasIndexTest  # BQ doesn't do the indexes that SQLA is loooking for.
+    del IdentityAutoincrementTest  # BQ doesn't do autoincrement
+    del PostCompileParamsTest  # BQ adds backticks to bind parameters, causing failure of tests TODO: fix this?
+
+elif packaging.version.parse(sqlalchemy.__version__) < packaging.version.parse("1.4"):
+    from sqlalchemy.testing.suite import LimitOffsetTest as _LimitOffsetTest
+
+    class LimitOffsetTest(_LimitOffsetTest):
+        @pytest.mark.skip("BigQuery doesn't allow an offset without a limit.")
+        def test_simple_offset(self):
+            pass
+
+        test_bound_offset = test_simple_offset
+
+    class TimestampMicrosecondsTest(_TimestampMicrosecondsTest):
+        data = datetime.datetime(2012, 10, 15, 12, 57, 18, 396, tzinfo=pytz.UTC)
+
+        def test_literal(self):
+            # The base tests doesn't set up the literal properly, because
+            # it doesn't pass its datatype to `literal`.
+
+            def literal(value):
+                assert value == self.data
+                return sqlalchemy.sql.elements.literal(value, self.datatype)
+
+            with mock.patch("sqlalchemy.testing.suite.test_types.literal", literal):
+                super(TimestampMicrosecondsTest, self).test_literal()
+
+        def test_select_direct(self, connection):
+            # This func added because this test was failing when passed the
+            # UTC timezone.
+
+            def literal(value, type_=None):
+                assert value == self.data
+
+                if type_ is not None:
+                    assert type_ is self.datatype
+
+                return sqlalchemy.sql.elements.literal(value, self.datatype)
+
+            with mock.patch("sqlalchemy.testing.suite.test_types.literal", literal):
+                super(TimestampMicrosecondsTest, self).test_select_direct(connection)
+
+    class InsertBehaviorTest(_InsertBehaviorTest):
+        @pytest.mark.skip(
+            "BQ has no autoinc and client-side defaults can't work for select."
+        )
+        def test_insert_from_select_autoinc(cls):
+            pass
 
     class SimpleUpdateDeleteTest(_SimpleUpdateDeleteTest):
         """The base tests fail if operations return rows for some reason."""
@@ -478,6 +536,46 @@ else:
                 config.db.execute(t.select().order_by(t.c.id)).fetchall(),
                 [(1, "d1"), (3, "d3")],
             )
+
+else:
+    from sqlalchemy.testing.suite import (
+        FetchLimitOffsetTest as _FetchLimitOffsetTest,
+        RowCountTest as _RowCountTest,
+    )
+
+    class FetchLimitOffsetTest(_FetchLimitOffsetTest):
+        @pytest.mark.skip("BigQuery doesn't allow an offset without a limit.")
+        def test_simple_offset(self):
+            pass
+
+        test_bound_offset = test_simple_offset
+        test_expr_offset = test_simple_offset_zero = test_simple_offset
+        test_limit_offset_nobinds = test_simple_offset  # TODO figure out
+        # how to prevent this from failing
+        # The original test is missing an order by.
+
+        # Also, note that sqlalchemy union is a union distinct, not a
+        # union all. This test caught that were were getting that wrong.
+        def test_limit_render_multiple_times(self, connection):
+            table = self.tables.some_table
+            stmt = select(table.c.id).order_by(table.c.id).limit(1).scalar_subquery()
+
+            u = sqlalchemy.union(select(stmt), select(stmt)).subquery().select()
+
+            self._assert_result(
+                connection,
+                u,
+                [(1,)],
+            )
+
+    del DifficultParametersTest  # exercises column names illegal in BQ
+    del DistinctOnTest  # expects unquoted table names.
+    del HasIndexTest  # BQ doesn't do the indexes that SQLA is loooking for.
+    del IdentityAutoincrementTest  # BQ doesn't do autoincrement
+
+    # This test makes makes assertions about generated sql and trips
+    # over the backquotes that we add everywhere. XXX Why do we do that?
+    del PostCompileParamsTest
 
     class TimestampMicrosecondsTest(_TimestampMicrosecondsTest):
         data = datetime.datetime(2012, 10, 15, 12, 57, 18, 396, tzinfo=pytz.UTC)
@@ -529,15 +627,70 @@ else:
         test_round_trip_executemany
     )
 
+    class RowCountTest(_RowCountTest):
+        @classmethod
+        def insert_data(cls, connection):
+            cls.data = data = [
+                ("Angela", "A"),
+                ("Andrew", "A"),
+                ("Anand", "A"),
+                ("Bob", "B"),
+                ("Bobette", "B"),
+                ("Buffy", "B"),
+                ("Charlie", "C"),
+                ("Cynthia", "C"),
+                ("Chris", "C"),
+            ]
 
-class CTETest(_CTETest):
-    @pytest.mark.skip("Can't use CTEs with insert")
-    def test_insert_from_select_round_trip(self):
-        pass
+            employees_table = cls.tables.employees
+            connection.execute(
+                employees_table.insert(),
+                [
+                    {"employee_id": i, "name": n, "department": d}
+                    for i, (n, d) in enumerate(data)
+                ],
+            )
 
-    @pytest.mark.skip("Recusive CTEs aren't supported.")
-    def test_select_recursive_round_trip(self):
-        pass
+    class InsertBehaviorTest(_InsertBehaviorTest):
+        @pytest.mark.skip(
+            "BQ has no autoinc and client-side defaults can't work for select."
+        )
+        def test_insert_from_select_autoinc(cls):
+            pass
+
+    class SimpleUpdateDeleteTest(_SimpleUpdateDeleteTest):
+        """The base tests fail if operations return rows for some reason."""
+
+        def test_update(self):
+            t = self.tables.plain_pk
+            r = config.db.execute(t.update().where(t.c.id == 2), data="d2_new")
+            assert not r.is_insert
+
+            eq_(
+                config.db.execute(t.select().order_by(t.c.id)).fetchall(),
+                [(1, "d1"), (2, "d2_new"), (3, "d3")],
+            )
+
+        def test_delete(self):
+            t = self.tables.plain_pk
+            r = config.db.execute(t.delete().where(t.c.id == 2))
+            assert not r.is_insert
+            eq_(
+                config.db.execute(t.select().order_by(t.c.id)).fetchall(),
+                [(1, "d1"), (3, "d3")],
+            )
+
+
+# Quotes aren't allowed in BigQuery table names.
+del QuotedNameArgumentTest
+
+
+# class InsertBehaviorTest(_InsertBehaviorTest):
+#     @pytest.mark.skip(
+#         "BQ has no autoinc and client-side defaults can't work for select."
+#     )
+#     def test_insert_from_select_autoinc(cls):
+#         pass
 
 
 class ExistsTest(_ExistsTest):
@@ -572,43 +725,42 @@ class ExistsTest(_ExistsTest):
         )
 
 
-class FetchLimitOffsetTest(_FetchLimitOffsetTest):
-    @pytest.mark.skip("BigQuery doesn't allow an offset without a limit.")
-    def test_simple_offset(self):
+# This test requires features (indexes, primary keys, etc., that BigQuery doesn't have.
+del LongNameBlowoutTest
+
+
+# class SimpleUpdateDeleteTest(_SimpleUpdateDeleteTest):
+#     """The base tests fail if operations return rows for some reason."""
+
+#     def test_update(self):
+#         t = self.tables.plain_pk
+#         r = config.db.execute(t.update().where(t.c.id == 2), data="d2_new")
+#         assert not r.is_insert
+#         # assert not r.returns_rows
+
+#         eq_(
+#             config.db.execute(t.select().order_by(t.c.id)).fetchall(),
+#             [(1, "d1"), (2, "d2_new"), (3, "d3")],
+#         )
+
+#     def test_delete(self):
+#         t = self.tables.plain_pk
+#         r = config.db.execute(t.delete().where(t.c.id == 2))
+#         assert not r.is_insert
+#         # assert not r.returns_rows
+#         eq_(
+#             config.db.execute(t.select().order_by(t.c.id)).fetchall(),
+#             [(1, "d1"), (3, "d3")],
+#         )
+
+
+class CTETest(_CTETest):
+    @pytest.mark.skip("Can't use CTEs with insert")
+    def test_insert_from_select_round_trip(self):
         pass
 
-    test_bound_offset = test_simple_offset
-    test_expr_offset = test_simple_offset_zero = test_simple_offset
-    test_limit_offset_nobinds = test_simple_offset  # TODO figure out
-    # how to prevent this from failing
-    # The original test is missing an order by.
-
-    # Also, note that sqlalchemy union is a union distinct, not a
-    # union all. This test caught that were were getting that wrong.
-    def test_limit_render_multiple_times(self, connection):
-        table = self.tables.some_table
-        stmt = select(table.c.id).order_by(table.c.id).limit(1).scalar_subquery()
-
-        u = sqlalchemy.union(select(stmt), select(stmt)).subquery().select()
-
-        self._assert_result(
-            connection,
-            u,
-            [(1,)],
-        )
-
-
-class InsertBehaviorTest(_InsertBehaviorTest):
-    @pytest.mark.skip(
-        "BQ has no autoinc and client-side defaults can't work for select."
-    )
-    def test_insert_from_select_autoinc(cls):
-        pass
-
-    @pytest.mark.skip(
-        "BQ has no autoinc and client-side defaults can't work for select."
-    )
-    def test_no_results_for_non_returning_insert(cls):
+    @pytest.mark.skip("Recusive CTEs aren't supported.")
+    def test_select_recursive_round_trip(self):
         pass
 
 
@@ -628,9 +780,3 @@ del ComponentReflectionTest  # Multiple tests re: CHECK CONSTRAINTS, etc which
 del ArrayTest  # only appears to apply to postgresql
 del BizarroCharacterFKResolutionTest
 del HasTableTest.test_has_table_cache  # TODO confirm whether BQ has table caching
-del DistinctOnTest  # expects unquoted table names.
-del HasIndexTest  # BQ doesn't do the indexes that SQLA is loooking for.
-del IdentityAutoincrementTest  # BQ doesn't do autoincrement
-del LongNameBlowoutTest  # Requires features (indexes, primary keys, etc., that BigQuery doesn't have.
-del PostCompileParamsTest  # BQ adds backticks to bind parameters, causing failure of tests TODO: fix this?
-del QuotedNameArgumentTest  # Quotes aren't allowed in BigQuery table names.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -30,6 +30,18 @@ from sqlalchemy_bigquery.base import BigQueryDDLCompiler, BigQueryDialect
 from . import fauxdbi
 
 sqlalchemy_version = packaging.version.parse(sqlalchemy.__version__)
+sqlalchemy_1_3_or_higher = pytest.mark.skipif(
+    sqlalchemy_version < packaging.version.parse("1.3"),
+    reason="requires sqlalchemy 1.3 or higher",
+)
+sqlalchemy_1_4_or_higher = pytest.mark.skipif(
+    sqlalchemy_version < packaging.version.parse("1.4"),
+    reason="requires sqlalchemy 1.4 or higher",
+)
+sqlalchemy_before_1_4 = pytest.mark.skipif(
+    sqlalchemy_version >= packaging.version.parse("1.4"),
+    reason="requires sqlalchemy 1.3 or lower",
+)
 sqlalchemy_before_2_0 = pytest.mark.skipif(
     sqlalchemy_version >= packaging.version.parse("2.0"),
     reason="requires sqlalchemy 1.3 or lower",

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -22,6 +22,8 @@ import sqlalchemy.exc
 
 from .conftest import setup_table
 from .conftest import (
+    sqlalchemy_1_4_or_higher,
+    sqlalchemy_before_1_4,
     sqlalchemy_2_0_or_higher,
     sqlalchemy_before_2_0,
 )
@@ -61,6 +63,7 @@ def test_cant_compile_unnamed_column(faux_conn, metadata):
         sqlalchemy.Column(sqlalchemy.Integer).compile(faux_conn)
 
 
+@sqlalchemy_1_4_or_higher
 def test_no_alias_for_known_tables(faux_conn, metadata):
     # See: https://github.com/googleapis/python-bigquery-sqlalchemy/issues/353
     table = setup_table(
@@ -82,6 +85,7 @@ def test_no_alias_for_known_tables(faux_conn, metadata):
     assert found_sql == expected_sql
 
 
+@sqlalchemy_1_4_or_higher
 def test_no_alias_for_known_tables_cte(faux_conn, metadata):
     # See: https://github.com/googleapis/python-bigquery-sqlalchemy/issues/368
     table = setup_table(
@@ -235,6 +239,7 @@ def test_no_implicit_join_for_inner_unnest(faux_conn, metadata):
     assert found_outer_sql == expected_outer_sql
 
 
+@sqlalchemy_1_4_or_higher
 def test_no_implicit_join_asterix_for_inner_unnest_no_table2_column(
     faux_conn, metadata
 ):
@@ -259,6 +264,7 @@ def test_no_implicit_join_asterix_for_inner_unnest_no_table2_column(
     assert found_outer_sql == expected_outer_sql
 
 
+@sqlalchemy_1_4_or_higher
 def test_no_implicit_join_for_inner_unnest_no_table2_column(faux_conn, metadata):
     # See: https://github.com/googleapis/python-bigquery-sqlalchemy/issues/368
     q = prepare_implicit_join_base_query(faux_conn, metadata, False, False)

--- a/tests/unit/test_compliance.py
+++ b/tests/unit/test_compliance.py
@@ -27,7 +27,7 @@ import sqlalchemy
 from sqlalchemy import Column, Integer, literal_column, select, String, Table, union
 from sqlalchemy.testing.assertions import eq_, in_
 
-from .conftest import setup_table
+from .conftest import setup_table, sqlalchemy_1_3_or_higher
 
 
 def assert_result(connection, sel, expected, params=()):
@@ -106,6 +106,7 @@ def test_percent_sign_round_trip(faux_conn, metadata):
     )
 
 
+@sqlalchemy_1_3_or_higher
 def test_empty_set_against_integer(faux_conn):
     table = some_table(faux_conn)
 
@@ -118,6 +119,7 @@ def test_empty_set_against_integer(faux_conn):
     assert_result(faux_conn, stmt, [], params={"q": []})
 
 
+@sqlalchemy_1_3_or_higher
 def test_null_in_empty_set_is_false(faux_conn):
     stmt = select(
         sqlalchemy.case(

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -20,13 +20,20 @@
 import datetime
 from decimal import Decimal
 
+import packaging.version
 import pytest
 import sqlalchemy
 from sqlalchemy import not_
 
 import sqlalchemy_bigquery
 
-from .conftest import setup_table
+from .conftest import (
+    setup_table,
+    sqlalchemy_version,
+    sqlalchemy_1_3_or_higher,
+    sqlalchemy_1_4_or_higher,
+    sqlalchemy_before_1_4,
+)
 
 
 def test_labels_not_forced(faux_conn):
@@ -218,6 +225,20 @@ def test_disable_quote(faux_conn):
     assert faux_conn.test_data["execute"][-1][0] == ("SELECT `t`.foo \nFROM `t`")
 
 
+@sqlalchemy_before_1_4
+def test_select_in_lit_13(faux_conn):
+    [[isin]] = faux_conn.execute(
+        sqlalchemy.select(sqlalchemy.literal(1).in_([1, 2, 3]))
+    )
+    assert isin
+    assert faux_conn.test_data["execute"][-1] == (
+        "SELECT %(param_1:INT64)s IN "
+        "(%(param_2:INT64)s, %(param_3:INT64)s, %(param_4:INT64)s) AS `anon_1`",
+        {"param_1": 1, "param_2": 1, "param_3": 2, "param_4": 3},
+    )
+
+
+@sqlalchemy_1_4_or_higher
 def test_select_in_lit(faux_conn, last_query):
     faux_conn.execute(sqlalchemy.select(sqlalchemy.literal(1).in_([1, 2, 3])))
     last_query(
@@ -227,45 +248,81 @@ def test_select_in_lit(faux_conn, last_query):
 
 
 def test_select_in_param(faux_conn, last_query):
-    faux_conn.execute(
+    [[isin]] = faux_conn.execute(
         sqlalchemy.select(
             sqlalchemy.literal(1).in_(sqlalchemy.bindparam("q", expanding=True))
         ),
         dict(q=[1, 2, 3]),
     )
-
-    last_query(
-        "SELECT %(param_1:INT64)s IN UNNEST(%(q:INT64)s) AS `anon_1`",
-        {"param_1": 1, "q": [1, 2, 3]},
-    )
+    if sqlalchemy_version >= packaging.version.parse("1.4"):
+        last_query(
+            "SELECT %(param_1:INT64)s IN UNNEST(%(q:INT64)s) AS `anon_1`",
+            {"param_1": 1, "q": [1, 2, 3]},
+        )
+    else:
+        assert isin
+        last_query(
+            "SELECT %(param_1:INT64)s IN UNNEST("
+            "[ %(q_1:INT64)s, %(q_2:INT64)s, %(q_3:INT64)s ]"
+            ") AS `anon_1`",
+            {"param_1": 1, "q_1": 1, "q_2": 2, "q_3": 3},
+        )
 
 
 def test_select_in_param1(faux_conn, last_query):
-    faux_conn.execute(
+    [[isin]] = faux_conn.execute(
         sqlalchemy.select(
             sqlalchemy.literal(1).in_(sqlalchemy.bindparam("q", expanding=True))
         ),
         dict(q=[1]),
     )
-    last_query(
-        "SELECT %(param_1:INT64)s IN UNNEST(%(q:INT64)s) AS `anon_1`",
-        {"param_1": 1, "q": [1]},
-    )
+    if sqlalchemy_version >= packaging.version.parse("1.4"):
+        last_query(
+            "SELECT %(param_1:INT64)s IN UNNEST(%(q:INT64)s) AS `anon_1`",
+            {"param_1": 1, "q": [1]},
+        )
+    else:
+        assert isin
+        last_query(
+            "SELECT %(param_1:INT64)s IN UNNEST(" "[ %(q_1:INT64)s ]" ") AS `anon_1`",
+            {"param_1": 1, "q_1": 1},
+        )
 
 
+@sqlalchemy_1_3_or_higher
 def test_select_in_param_empty(faux_conn, last_query):
-    faux_conn.execute(
+    [[isin]] = faux_conn.execute(
         sqlalchemy.select(
             sqlalchemy.literal(1).in_(sqlalchemy.bindparam("q", expanding=True))
         ),
         dict(q=[]),
     )
-    last_query(
-        "SELECT %(param_1:INT64)s IN UNNEST(%(q:INT64)s) AS `anon_1`",
-        {"param_1": 1, "q": []},
+    if sqlalchemy_version >= packaging.version.parse("1.4"):
+        last_query(
+            "SELECT %(param_1:INT64)s IN UNNEST(%(q:INT64)s) AS `anon_1`",
+            {"param_1": 1, "q": []},
+        )
+    else:
+        assert not isin
+        last_query(
+            "SELECT %(param_1:INT64)s IN UNNEST([  ]) AS `anon_1`", {"param_1": 1}
+        )
+
+
+@sqlalchemy_before_1_4
+def test_select_notin_lit13(faux_conn):
+    [[isnotin]] = faux_conn.execute(
+        sqlalchemy.select(sqlalchemy.literal(0).notin_([1, 2, 3]))
+    )
+    assert isnotin
+    assert faux_conn.test_data["execute"][-1] == (
+        "SELECT (%(param_1:INT64)s NOT IN "
+        "(%(param_2:INT64)s, %(param_3:INT64)s, %(param_4:INT64)s)) AS `anon_1`",
+        {"param_1": 0, "param_2": 1, "param_3": 2, "param_4": 3},
     )
 
 
+@sqlalchemy_1_4_or_higher
 def test_select_notin_lit(faux_conn, last_query):
     faux_conn.execute(sqlalchemy.select(sqlalchemy.literal(0).notin_([1, 2, 3])))
     last_query(
@@ -275,29 +332,45 @@ def test_select_notin_lit(faux_conn, last_query):
 
 
 def test_select_notin_param(faux_conn, last_query):
-    faux_conn.execute(
+    [[isnotin]] = faux_conn.execute(
         sqlalchemy.select(
             sqlalchemy.literal(1).notin_(sqlalchemy.bindparam("q", expanding=True))
         ),
         dict(q=[1, 2, 3]),
     )
-    last_query(
-        "SELECT (%(param_1:INT64)s NOT IN UNNEST(%(q:INT64)s)) AS `anon_1`",
-        {"param_1": 1, "q": [1, 2, 3]},
-    )
+    if sqlalchemy_version >= packaging.version.parse("1.4"):
+        last_query(
+            "SELECT (%(param_1:INT64)s NOT IN UNNEST(%(q:INT64)s)) AS `anon_1`",
+            {"param_1": 1, "q": [1, 2, 3]},
+        )
+    else:
+        assert not isnotin
+        last_query(
+            "SELECT (%(param_1:INT64)s NOT IN UNNEST("
+            "[ %(q_1:INT64)s, %(q_2:INT64)s, %(q_3:INT64)s ]"
+            ")) AS `anon_1`",
+            {"param_1": 1, "q_1": 1, "q_2": 2, "q_3": 3},
+        )
 
 
+@sqlalchemy_1_3_or_higher
 def test_select_notin_param_empty(faux_conn, last_query):
-    faux_conn.execute(
+    [[isnotin]] = faux_conn.execute(
         sqlalchemy.select(
             sqlalchemy.literal(1).notin_(sqlalchemy.bindparam("q", expanding=True))
         ),
         dict(q=[]),
     )
-    last_query(
-        "SELECT (%(param_1:INT64)s NOT IN UNNEST(%(q:INT64)s)) AS `anon_1`",
-        {"param_1": 1, "q": []},
-    )
+    if sqlalchemy_version >= packaging.version.parse("1.4"):
+        last_query(
+            "SELECT (%(param_1:INT64)s NOT IN UNNEST(%(q:INT64)s)) AS `anon_1`",
+            {"param_1": 1, "q": []},
+        )
+    else:
+        assert isnotin
+        last_query(
+            "SELECT (%(param_1:INT64)s NOT IN UNNEST([  ])) AS `anon_1`", {"param_1": 1}
+        )
 
 
 def test_literal_binds_kwarg_with_an_IN_operator_252(faux_conn):
@@ -318,6 +391,7 @@ def test_literal_binds_kwarg_with_an_IN_operator_252(faux_conn):
     )
 
 
+@sqlalchemy_1_4_or_higher
 @pytest.mark.parametrize("alias", [True, False])
 def test_unnest(faux_conn, alias):
     from sqlalchemy import String
@@ -335,6 +409,7 @@ def test_unnest(faux_conn, alias):
     )
 
 
+@sqlalchemy_1_4_or_higher
 @pytest.mark.parametrize("alias", [True, False])
 def test_table_valued_alias_w_multiple_references_to_the_same_table(faux_conn, alias):
     from sqlalchemy import String
@@ -353,6 +428,7 @@ def test_table_valued_alias_w_multiple_references_to_the_same_table(faux_conn, a
     )
 
 
+@sqlalchemy_1_4_or_higher
 @pytest.mark.parametrize("alias", [True, False])
 def test_unnest_w_no_table_references(faux_conn, alias):
     fcall = sqlalchemy.func.unnest([1, 2, 3])
@@ -376,6 +452,10 @@ def test_array_indexing(faux_conn, metadata):
     assert got == "SELECT `t`.`a`[OFFSET(%(a_1:INT64)s)] AS `anon_1` \nFROM `t`"
 
 
+@pytest.mark.skipif(
+    packaging.version.parse(sqlalchemy.__version__) < packaging.version.parse("1.4"),
+    reason="regexp_match support requires version 1.4 or higher",
+)
 def test_visit_regexp_match_op_binary(faux_conn):
     table = setup_table(
         faux_conn,
@@ -392,6 +472,10 @@ def test_visit_regexp_match_op_binary(faux_conn):
     assert result == expected
 
 
+@pytest.mark.skipif(
+    packaging.version.parse(sqlalchemy.__version__) < packaging.version.parse("1.4"),
+    reason="regexp_match support requires version 1.4 or higher",
+)
 def test_visit_not_regexp_match_op_binary(faux_conn):
     table = setup_table(
         faux_conn,

--- a/tests/unit/test_sqlalchemy_bigquery.py
+++ b/tests/unit/test_sqlalchemy_bigquery.py
@@ -10,6 +10,7 @@ import google.api_core.exceptions
 from google.cloud import bigquery
 from google.cloud.bigquery.dataset import DatasetListItem
 from google.cloud.bigquery.table import TableListItem
+import packaging.version
 import pytest
 import sqlalchemy
 
@@ -226,7 +227,12 @@ def test_unnest_function(args, kw):
 
     f = sqlalchemy.func.unnest(*args, **kw)
     assert isinstance(f.type, sqlalchemy.String)
-    assert isinstance(sqlalchemy.select(f).subquery().c.unnest.type, sqlalchemy.String)
+    if packaging.version.parse(sqlalchemy.__version__) >= packaging.version.parse(
+        "1.4"
+    ):
+        assert isinstance(
+            sqlalchemy.select(f).subquery().c.unnest.type, sqlalchemy.String
+        )
 
 
 @mock.patch("sqlalchemy_bigquery._helpers.create_bigquery_client")


### PR DESCRIPTION
Reverts googleapis/python-bigquery-sqlalchemy#1013, this should have been merged after #987 