### PR TITLE
feat: adds user agent parameters to two functions

### DIFF
--- a/sqlalchemy_bigquery/_helpers.py
+++ b/sqlalchemy_bigquery/_helpers.py
@@ -45,7 +45,7 @@ def create_bigquery_client(
     default_query_job_config: Optional[google.cloud.bigquery.job.QueryJobConfig] = None,
     location: Optional[str] = None,
     project_id: Optional[str] = None,
-    user_agent: Optional[str] = None,
+    user_agent: Optional[google.api_core.client_info.ClientInfo] = None,
 ) -> google.cloud.bigquery.Client:
     """Construct a BigQuery client object.
 

--- a/sqlalchemy_bigquery/_helpers.py
+++ b/sqlalchemy_bigquery/_helpers.py
@@ -6,6 +6,7 @@
 
 import functools
 import re
+from typing import Optional
 
 from google.api_core import client_info
 import google.auth
@@ -14,6 +15,7 @@ from google.oauth2 import service_account
 import sqlalchemy
 import base64
 import json
+
 
 
 USER_AGENT_TEMPLATE = "sqlalchemy/{}"

--- a/sqlalchemy_bigquery/_helpers.py
+++ b/sqlalchemy_bigquery/_helpers.py
@@ -24,19 +24,47 @@ SCOPES = (
 )
 
 
-def google_client_info():
-    user_agent = USER_AGENT_TEMPLATE.format(sqlalchemy.__version__)
+def google_client_info(user_agent=None):
+    """
+    Return a client_info object, with an optional user agent
+    string.  If user_agent is None, use a default value.
+    """
+
+    if user_agent is None:
+        user_agent = USER_AGENT_TEMPLATE.format(sqlalchemy.__version__)
     return client_info.ClientInfo(user_agent=user_agent)
 
 
 def create_bigquery_client(
-    credentials_info=None,
-    credentials_path=None,
-    credentials_base64=None,
-    default_query_job_config=None,
-    location=None,
-    project_id=None,
-):
+    credentials_info: Optional[dict] = None,
+    credentials_path: Optional[str] = None,
+    credentials_base64: Optional[str] = None,
+    default_query_job_config: Optional[google.cloud.bigquery.job.QueryJobConfig] = None,
+    location: Optional[str] = None,
+    project_id: Optional[str] = None,
+    user_agent: Optional[str] = None,
+) -> google.cloud.bigquery.Client:
+    
+    """Construct a BigQuery client object.
+
+    Args:
+        credentials_info Optional[dict]: 
+        credentials_path Optional[str]:
+        credentials_base64 Optional[str]:
+        default_query_job_config (Optional[google.cloud.bigquery.job.QueryJobConfig]):
+            Default ``QueryJobConfig``.
+            Will be merged into job configs passed into the ``query`` method.
+        location (Optional[str]):
+            Default location for jobs / datasets / tables.
+        project_id (Optional[str]):
+            Project ID for the project which the client acts on behalf of.
+        user_agent (Optional[google.api_core.client_info.ClientInfo]):
+            The client info used to send a user-agent string along with API
+            requests. If ``None``, then default info will be used. Generally,
+            you only need to set this if you're developing your own library
+            or partner tool.
+    """
+    
     default_project = None
 
     if credentials_base64:
@@ -60,8 +88,10 @@ def create_bigquery_client(
     if project_id is None:
         project_id = default_project
 
+    client_info = google_client_info(user_agent=user_agent)
+
     return bigquery.Client(
-        client_info=google_client_info(),
+        client_info=client_info,
         project=project_id,
         credentials=credentials,
         location=location,

--- a/sqlalchemy_bigquery/_helpers.py
+++ b/sqlalchemy_bigquery/_helpers.py
@@ -25,7 +25,9 @@ SCOPES = (
 )
 
 
-def google_client_info(user_agent=None):
+def google_client_info(
+    user_agent: Optional[str] = None,
+) -> google.api_core.client_info.ClientInfo:
     """
     Return a client_info object, with an optional user agent
     string.  If user_agent is None, use a default value.

--- a/sqlalchemy_bigquery/_helpers.py
+++ b/sqlalchemy_bigquery/_helpers.py
@@ -17,7 +17,6 @@ import base64
 import json
 
 
-
 USER_AGENT_TEMPLATE = "sqlalchemy/{}"
 SCOPES = (
     "https://www.googleapis.com/auth/bigquery",
@@ -46,11 +45,10 @@ def create_bigquery_client(
     project_id: Optional[str] = None,
     user_agent: Optional[str] = None,
 ) -> google.cloud.bigquery.Client:
-    
     """Construct a BigQuery client object.
 
     Args:
-        credentials_info Optional[dict]: 
+        credentials_info Optional[dict]:
         credentials_path Optional[str]:
         credentials_base64 Optional[str]:
         default_query_job_config (Optional[google.cloud.bigquery.job.QueryJobConfig]):
@@ -66,7 +64,7 @@ def create_bigquery_client(
             you only need to set this if you're developing your own library
             or partner tool.
     """
-    
+
     default_project = None
 
     if credentials_base64:

--- a/tests/system/test_helpers.py
+++ b/tests/system/test_helpers.py
@@ -104,3 +104,11 @@ def test_create_bigquery_client_with_credentials_base64_respects_project(
         project_id="connection-url-project",
     )
     assert bqclient.project == "connection-url-project"
+
+
+def test_create_bigquery_client_with_user_agent(module_under_test):
+    user_agent = "test_user_agent"
+
+    bqclient = module_under_test.create_bigquery_client(user_agent=user_agent)
+
+    assert bqclient._connection._client_info.user_agent == user_agent

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -255,4 +255,4 @@ def test_substitute_re_func_self(module_under_test):
 )
 def test_google_client_info(user_agent, expected_user_agent):
     client_info = _helpers.google_client_info(user_agent=user_agent)
-    assert client_info.to_user_agent() == expected_user_agent
+    assert client_info.to_user_agent().startswith(expected_user_agent)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -246,6 +246,7 @@ def test_substitute_re_func_self(module_under_test):
         == "some hah and FOO is good"
     )
 
+
 @pytest.mark.parametrize(
     "user_agent, expected_user_agent",
     [

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -12,6 +12,7 @@ import google.auth
 import google.auth.credentials
 import pytest
 from google.oauth2 import service_account
+from sqlalchemy_bigquery import _helpers
 
 
 class AnonymousCredentialsWithProject(google.auth.credentials.AnonymousCredentials):
@@ -244,3 +245,14 @@ def test_substitute_re_func_self(module_under_test):
         Replacer("hah").foo_to_bar("some foo and FOO is good")
         == "some hah and FOO is good"
     )
+
+@pytest.mark.parametrize(
+    "user_agent, expected_user_agent",
+    [
+        (None, f"sqlalchemy/{_helpers.sqlalchemy.__version__}"),
+        ("my-user-agent", "my-user-agent"),
+    ],
+)
+def test_google_client_info(user_agent, expected_user_agent):
+    client_info = _helpers.google_client_info(user_agent=user_agent)
+    assert client_info.to_user_agent() == expected_user_agent


### PR DESCRIPTION
This adds:

* the ability for users to set a customer user agent (instead of the default user agent string that is currently hard coded in)
* docstrings and type hinting for the functions that we touched
* tests to test the new code path in `google_client_info`.

- [x] Add tests to check various states/edge cases (TBD)

Fixes #1082  🦕
