### PR TITLE
Bug: removes a compliance test that fails and replaces with unit test

### DIFF
--- a/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
+++ b/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
@@ -47,6 +47,7 @@ from sqlalchemy.testing.suite import (
     QuotedNameArgumentTest,
     SimpleUpdateDeleteTest as _SimpleUpdateDeleteTest,
     TimestampMicrosecondsTest as _TimestampMicrosecondsTest,
+    WindowFunctionTest,
 )
 
 from sqlalchemy.testing.suite.test_types import (
@@ -636,3 +637,6 @@ del IdentityAutoincrementTest  # BQ doesn't do autoincrement
 del LongNameBlowoutTest  # Requires features (indexes, primary keys, etc., that BigQuery doesn't have.
 del PostCompileParamsTest  # BQ adds backticks to bind parameters, causing failure of tests TODO: fix this?
 del QuotedNameArgumentTest  # Quotes aren't allowed in BigQuery table names.
+del (
+    WindowFunctionTest.test_window_rows_between
+)  # test expects BQ to return sorted results

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -521,7 +521,7 @@ def test_window_rows_between(faux_conn):
     Note: that test only appears in:
     sqlalchemy/lib/sqlalchemy/testing/suite/test_select.py
     in version 2.0.32. It appears as though that test will be
-    replaced with the a similar but new test called:
+    replaced with a similar but new test called:
     'test_window_rows_between_w_caching'
     due to the fact the rows are part of the cache key right now and
     not handled as binds.  This is related to sqlalchemy Issue #11515

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -520,7 +520,7 @@ def test_window_rows_between(faux_conn):
 
     Note: that test only appears in:
     sqlalchemy/lib/sqlalchemy/testing/suite/test_select.py
-    in version 2.0.32. It appears as those that test will be
+    in version 2.0.32. It appears as though that test will be
     replaced with the a similar but new test called:
     'test_window_rows_between_w_caching'
     due to the fact the rows are part of the cache key right now and

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -515,7 +515,7 @@ def test_window_rows_between(faux_conn):
     test in sqlalchemy's suite of compliance tests.
 
     Their test is expecting things in sorted order and BQ
-    doesn't return sorted results they way they expect so that
+    doesn't return sorted results the way they expect so that
     test fails.
 
     Note: that test only appears in:

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -507,3 +507,53 @@ def test_visit_mod_binary(faux_conn):
     expected = "MOD(`table`.`foo`, %(foo_1:INT64)s)"
 
     assert result == expected
+
+
+def test_window_rows_between(faux_conn):
+    """This is a replacement for the
+    'test_window_rows_between'
+    test in sqlalchemy's suite of compliance tests.
+
+    Their test is expecting things in sorted order and BQ
+    doesn't return sorted results they way they expect so that
+    test fails.
+
+    Note: that test only appears in:
+    sqlalchemy/lib/sqlalchemy/testing/suite/test_select.py
+    in version 2.0.32. It appears as those that test will be
+    replaced with the a similar but new test called:
+    'test_window_rows_between_w_caching'
+    due to the fact the rows are part of the cache key right now and
+    not handled as binds.  This is related to sqlalchemy Issue #11515
+
+    It is expected the new test will also have the same sorting failure.
+    """
+
+    table = setup_table(
+        faux_conn,
+        "table",
+        sqlalchemy.Column("id", sqlalchemy.String),
+        sqlalchemy.Column("col1", sqlalchemy.Integer),
+        sqlalchemy.Column("col2", sqlalchemy.Integer),
+    )
+
+    stmt = sqlalchemy.select(
+        sqlalchemy.func.max(table.c.col2).over(
+            order_by=[table.c.col1],
+            rows=(-5, 0),
+        )
+    )
+
+    sql = stmt.compile(
+        dialect=faux_conn.dialect,
+        compile_kwargs={"literal_binds": True},
+    )
+
+    result = str(sql)
+    expected = (
+        "SELECT max(`table`.`col2`) "
+        "OVER (ORDER BY `table`.`col1` "
+        "ROWS BETWEEN 5 PRECEDING AND CURRENT ROW) AS `anon_1` \n"  # newline character required here to match
+        "FROM `table`"
+    )
+    assert result == expected


### PR DESCRIPTION
This bugfix removes a sqlalchemy compliance test that expects results in sorted order, which BQ does not do using the SQL statement found in that test.
We replace that test with a related unit test to confirm that the windowing feature is correctly created in our SQL statements.

Fixes #1109 🦕

Another PR will address these issues related to Enum Errors.
#1102 🦕
#1103 🦕
#1104 🦕
#1105 🦕
#1106 🦕
#1107 🦕
#1108 🦕

