### PR TITLE
Feat: Updates colspec to account for sqlalchemy Enum

### DIFF
--- a/sqlalchemy_bigquery/base.py
+++ b/sqlalchemy_bigquery/base.py
@@ -1018,6 +1018,7 @@ class BigQueryDialect(DefaultDialect):
         sqlalchemy.sql.sqltypes.Time: BQClassTaggedStr,
         sqlalchemy.sql.sqltypes.TIMESTAMP: BQTimestamp,
         sqlalchemy.sql.sqltypes.ARRAY: BQArray,
+        sqlalchemy.sql.sqltypes.Enum: sqlalchemy.sql.sqltypes.Enum,
     }
 
     def __init__(


### PR DESCRIPTION
Flakybot was flagging a number of tests that failed when handling sqlalchemy Enums. In consultation with members of the sqlalchemy team, it was suggested to follow an approach similar to the one used by sqlite: To modify the colspec.

The backstory is this:
We made a class (`BQString`) that inherits from sqlalchemy's `String`.
`BQString` has one function (and only one).
It will process string literals to replace single percents with double percents.

```
def process_string_literal(value):
    return repr(value.replace("%", "%%"))


class BQString(String):
    def literal_processor(self, dialect):
        return process_string_literal
```

Where the [issue comes into play is this](https://github.com/sqlalchemy/sqlalchemy/discussions/11734#discussioncomment-10329327): 
> The problem is that Enum is a subclass of String, so if you are defining a new dialect specific class of String, you would need to accommodate for Enum as well. The simplest way assuming you don't need BQString's logic for Enum is to map Enum to itself, which would bypass the BQString type for Enum. 


Fixes #1102 🦕
Fixes #1103 🦕
Fixes #1104 🦕
Fixes #1105 🦕
Fixes #1106 🦕
Fixes #1107 🦕
Fixes #1108 🦕


