### PR TITLE
feat: add JSON type, bindparam support

### DIFF
--- a/sqlalchemy_bigquery/__init__.py
+++ b/sqlalchemy_bigquery/__init__.py
@@ -23,7 +23,6 @@ SQLAlchemy dialect for Google BigQuery
 import warnings
 
 from .version import __version__
-
 from .base import BigQueryDialect, dialect
 from ._types import (
     ARRAY,
@@ -37,6 +36,7 @@ from ._types import (
     FLOAT64,
     INT64,
     INTEGER,
+    JSON,
     NUMERIC,
     RECORD,
     STRING,
@@ -44,7 +44,6 @@ from ._types import (
     TIME,
     TIMESTAMP,
 )
-
 from . import _versions_helpers
 
 sys_major, sys_minor, sys_micro = _versions_helpers.extract_runtime_version()
@@ -74,6 +73,7 @@ __all__ = [
     "FLOAT64",
     "INT64",
     "INTEGER",
+    "JSON",
     "NUMERIC",
     "RECORD",
     "STRING",

--- a/sqlalchemy_bigquery/__init__.py
+++ b/sqlalchemy_bigquery/__init__.py
@@ -23,6 +23,7 @@ SQLAlchemy dialect for Google BigQuery
 import warnings
 
 from .version import __version__
+
 from .base import BigQueryDialect, dialect
 from ._types import (
     ARRAY,
@@ -44,6 +45,7 @@ from ._types import (
     TIME,
     TIMESTAMP,
 )
+
 from . import _versions_helpers
 
 sys_major, sys_minor, sys_micro = _versions_helpers.extract_runtime_version()

--- a/sqlalchemy_bigquery/_json.py
+++ b/sqlalchemy_bigquery/_json.py
@@ -1,0 +1,8 @@
+import sqlalchemy
+
+
+class JSON(sqlalchemy.sql.sqltypes.JSON):
+    def bind_expression(self, bindvalue):
+        # JSON query parameters have type STRING
+        # This hook ensures that the rendered expression has type JSON
+        return sqlalchemy.func.PARSE_JSON(bindvalue, type_=self)

--- a/sqlalchemy_bigquery/_types.py
+++ b/sqlalchemy_bigquery/_types.py
@@ -27,6 +27,7 @@ try:
 except ImportError:  # pragma: NO COVER
     pass
 
+from ._json import JSON
 from ._struct import STRUCT
 
 _type_map = {
@@ -41,6 +42,7 @@ _type_map = {
     "FLOAT": sqlalchemy.types.Float,
     "INT64": sqlalchemy.types.Integer,
     "INTEGER": sqlalchemy.types.Integer,
+    "JSON": JSON,
     "NUMERIC": sqlalchemy.types.Numeric,
     "RECORD": STRUCT,
     "STRING": sqlalchemy.types.String,
@@ -61,6 +63,7 @@ FLOAT64 = _type_map["FLOAT64"]
 FLOAT = _type_map["FLOAT"]
 INT64 = _type_map["INT64"]
 INTEGER = _type_map["INTEGER"]
+JSON = _type_map["JSON"]
 NUMERIC = _type_map["NUMERIC"]
 RECORD = _type_map["RECORD"]
 STRING = _type_map["STRING"]

--- a/sqlalchemy_bigquery/base.py
+++ b/sqlalchemy_bigquery/base.py
@@ -548,7 +548,10 @@ class BigQueryCompiler(_struct.SQLCompiler, vendored_postgresql.PGCompiler):
         bq_type = self.__remove_type_parameter(bq_type)
 
         if bq_type == "JSON":
-
+            # FIXME: JSON is not a member of `SqlParameterScalarTypes` in the DBAPI
+            # For now, we hack around this by:
+            # - Rewriting the bindparam type to STRING
+            # - Applying a bind expression that converts the parameter back to JSON
             bq_type = "STRING"
 
         assert_(param != "%s", f"Unexpected param: {param}")
@@ -646,14 +649,6 @@ class BigQueryTypeCompiler(GenericTypeCompiler):
     visit_DECIMAL = visit_NUMERIC
 
     def visit_JSON(self, type_, **kw):
-        if isinstance(
-            kw.get("type_expression"), sqlalchemy.sql.expression.BindParameter
-        ):  # bindparam
-            # FIXME: JSON is not a member of `SqlParameterScalarTypes` in the DBAPI
-            # For now, we hack around this by:
-            # - Rewriting the bindparam type to STRING
-            # - Applying a bind expression that converts the parameter back to JSON
-            return "STRING"
         return "JSON"
 
 

--- a/sqlalchemy_bigquery/base.py
+++ b/sqlalchemy_bigquery/base.py
@@ -548,10 +548,7 @@ class BigQueryCompiler(_struct.SQLCompiler, vendored_postgresql.PGCompiler):
         bq_type = self.__remove_type_parameter(bq_type)
 
         if bq_type == "JSON":
-            # FIXME: JSON is not a member of `SqlParameterScalarTypes` in the DBAPI
-            # For now, we hack around this by:
-            # - Rewriting the bindparam type to STRING
-            # - Applying a bind expression that converts the parameter back to JSON
+
             bq_type = "STRING"
 
         assert_(param != "%s", f"Unexpected param: {param}")
@@ -649,6 +646,14 @@ class BigQueryTypeCompiler(GenericTypeCompiler):
     visit_DECIMAL = visit_NUMERIC
 
     def visit_JSON(self, type_, **kw):
+        if isinstance(
+            kw.get("type_expression"), sqlalchemy.sql.expression.BindParameter
+        ):  # bindparam
+            # FIXME: JSON is not a member of `SqlParameterScalarTypes` in the DBAPI
+            # For now, we hack around this by:
+            # - Rewriting the bindparam type to STRING
+            # - Applying a bind expression that converts the parameter back to JSON
+            return "STRING"
         return "JSON"
 
 

--- a/tests/unit/test__json.py
+++ b/tests/unit/test__json.py
@@ -43,7 +43,7 @@ def test_set_json_serde(faux_conn, metadata, json_table, json_data):
 def test_json_create(faux_conn, metadata, json_table, json_data):
     expr = sqlalchemy.schema.CreateTable(json_table)
     sql = expr.compile(faux_conn.engine).string
-    assert sql == ("\nCREATE TABLE `json_table` (\n" "\t`json` JSON\n" ") \n\n")
+    assert sql == "\nCREATE TABLE `json_table` (\n\t`json` JSON\n) \n\n"
 
 
 def test_json_insert(faux_conn, metadata, json_table, json_data):

--- a/tests/unit/test__json.py
+++ b/tests/unit/test__json.py
@@ -1,0 +1,64 @@
+import json
+from unittest import mock
+
+import pytest
+import sqlalchemy
+
+
+@pytest.fixture
+def json_table(metadata):
+    from sqlalchemy_bigquery import JSON
+
+    return sqlalchemy.Table("json_table", metadata, sqlalchemy.Column("json", JSON))
+
+
+@pytest.fixture
+def json_data():
+    return {"foo": "bar"}
+
+
+def test_set_json_serde(faux_conn, metadata, json_table, json_data):
+    from sqlalchemy_bigquery import JSON
+
+    json_serializer = mock.Mock(side_effect=json.dumps)
+    json_deserializer = mock.Mock(side_effect=json.loads)
+
+    engine = sqlalchemy.create_engine(
+        "bigquery://myproject/mydataset",
+        json_serializer=json_serializer,
+        json_deserializer=json_deserializer,
+    )
+
+    json_column = json_table.c.json
+
+    process_bind = json_column.type.bind_processor(engine.dialect)
+    process_bind(json_data)
+    assert json_serializer.mock_calls == [mock.call(json_data)]
+
+    process_result = json_column.type.result_processor(engine.dialect, JSON)
+    process_result(json.dumps(json_data))
+    assert json_deserializer.mock_calls == [mock.call(json.dumps(json_data))]
+
+
+def test_json_create(faux_conn, metadata, json_table, json_data):
+    expr = sqlalchemy.schema.CreateTable(json_table)
+    sql = expr.compile(faux_conn.engine).string
+    assert sql == ("\nCREATE TABLE `json_table` (\n" "\t`json` JSON\n" ") \n\n")
+
+
+def test_json_insert(faux_conn, metadata, json_table, json_data):
+    expr = sqlalchemy.insert(json_table).values(json=json_data)
+    sql = expr.compile(faux_conn.engine).string
+    assert (
+        sql == "INSERT INTO `json_table` (`json`) VALUES (PARSE_JSON(%(json:STRING)s))"
+    )
+
+
+def test_json_where(faux_conn, metadata, json_table, json_data):
+    expr = sqlalchemy.select(json_table.c.json).where(json_table.c.json == json_data)
+    sql = expr.compile(faux_conn.engine).string
+    assert sql == (
+        "SELECT `json_table`.`json` \n"
+        "FROM `json_table` \n"
+        "WHERE `json_table`.`json` = PARSE_JSON(%(json_1:STRING)s)"
+    )


### PR DESCRIPTION
Extracted from googleapis/python-bigquery-sqlalchemy#1146, this is a smaller set of changes that establish a JSON type.

Changes:

- Export a JSON type
- Accept `json_serializer` / `json_deserializer` dialect kwargs
- Handle JSON bind parameters
- Tests

Once this is merged, users will be able to:

- Define tables with JSON columns
- Reference JSON columns in expressions
- Submit JSON query parameters (as STRINGs, with output conversion back to JSON)

In future PRs, we can add support for:

- JSON comparator conversion functions (BOOL / LAX_BOOL, etc.)
- JSON indexing operations

Fixes googleapis/google-cloud-python#15806 🦕
