### PR TITLE
fix: compilation of a labeled custom FunctionElement when used in grouping

### DIFF
--- a/sqlalchemy_bigquery/base.py
+++ b/sqlalchemy_bigquery/base.py
@@ -343,10 +343,8 @@ class BigQueryCompiler(_struct.SQLCompiler, vendored_postgresql.PGCompiler):
         if within_group_by:
             column_label = args[0]
             sql_keywords = {"GROUPING SETS", "ROLLUP", "CUBE"}
-            for keyword in sql_keywords:
-                if keyword in str(column_label):
-                    break
-            else:  # for/else always happens unless break gets called
+            label_str = column_label.compile(dialect=self.dialect).string
+            if not any(keyword in label_str for keyword in sql_keywords):
                 kwargs["render_label_as_label"] = column_label
 
         return super(BigQueryCompiler, self).visit_label(*args, **kwargs)

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -417,3 +417,41 @@ def test_complex_grouping_ops_vs_nested_grouping_ops(
     )
 
     assert found_sql == expected_sql
+
+
+def test_label_compiler(faux_conn, metadata):
+    class CustomLower(sqlalchemy.sql.functions.FunctionElement):
+        name = "custom_lower"
+
+    @sqlalchemy.ext.compiler.compiles(CustomLower)
+    def compile_custom_intersect(element, compiler, **kwargs):
+        if compiler.dialect.name != "bigquery":
+            raise sqlalchemy.exc.CompileError(
+                f"custom_lower is not supported for dialect {compiler.dialect.name}"
+            )
+
+        clauses = list(element.clauses)
+        field = compiler.process(clauses[0], **kwargs)
+        return f"LOWER({field})"
+
+    table1 = setup_table(
+        faux_conn,
+        "table1",
+        metadata,
+        sqlalchemy.Column("foo", sqlalchemy.String),
+        sqlalchemy.Column("bar", sqlalchemy.Integer),
+    )
+
+    lower_foo = CustomLower(table1.c.foo).label("some_label")
+    q = (
+        sqlalchemy.select(lower_foo, sqlalchemy.func.max(table1.c.bar))
+        .select_from(table1)
+        .group_by(lower_foo)
+    )
+    expected_sql = (
+        "SELECT LOWER(`table1`.`foo`) AS `some_label`, max(`table1`.`bar`) AS `max_1` \n"
+        "FROM `table1` GROUP BY `some_label`"
+    )
+
+    found_sql = q.compile(faux_conn).string
+    assert found_sql == expected_sql

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -426,7 +426,8 @@ def test_label_compiler(faux_conn, metadata):
     @sqlalchemy.ext.compiler.compiles(CustomLower)
     def compile_custom_intersect(element, compiler, **kwargs):
         if compiler.dialect.name != "bigquery":
-            raise sqlalchemy.exc.CompileError(
+            # We only test with the BigQuery dialect, so this should never happen.
+            raise sqlalchemy.exc.CompileError(  # pragma: NO COVER
                 f"custom_lower is not supported for dialect {compiler.dialect.name}"
             )
 


### PR DESCRIPTION
If we have a labeled custom function that we are grouping by, and the function does not support the `default` dialect, we can not compile our query.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-sqlalchemy/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [N/A] Appropriate docs were updated (if necessary)

Fixes #1150 🦕
