### PR TITLE
chore: updates owlbot and renovate.json to help control dependency when Python 3.9 is used.

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -53,6 +53,7 @@ s.move(
         # exclude gh actions as credentials are needed for tests
         ".github/workflows",
         "README.rst",
+        "renovate.json",
     ],
 )
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,12 @@
   "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
-  }
+  },
+  "packageRules": [
+    {
+      "matchFileNames": ["requirements.txt"],
+      "matchStrings": ["geoalchemy2 (.*); python_version == '3.9'"],
+      "allowedVersions": ">= 0.17.1, < 0.18.0"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "packageRules": [
     {
       "matchFileNames": ["requirements.txt"],
-      "matchStrings": ["geoalchemy2 (.*); python_version == '3.9'"],
+      "matchStrings": ["geoalchemy2(.*); python_version == '3.9'"],
       "allowedVersions": ">= 0.17.1, < 0.18.0"
     }
   ]

--- a/samples/snippets/requirements.txt
+++ b/samples/snippets/requirements.txt
@@ -1,7 +1,8 @@
 alembic==1.16.4;  python_version >= '3.9'
 certifi==2025.7.14
 charset-normalizer==3.4.2
-geoalchemy2==0.18.0
+geoalchemy2===0.17.1; python_version == '3.9'
+geoalchemy2==0.18.0; python_version >= '3.10'
 google-api-core[grpc]==2.25.1
 google-auth==2.40.3
 google-cloud-bigquery==3.35.1; python_version >= '3.9'

--- a/samples/snippets/requirements.txt
+++ b/samples/snippets/requirements.txt
@@ -1,17 +1,17 @@
 alembic==1.16.4;  python_version >= '3.9'
 certifi==2025.7.14
 charset-normalizer==3.4.2
-geoalchemy2==0.17.1
+geoalchemy2==0.18.0
 google-api-core[grpc]==2.25.1
 google-auth==2.40.3
-google-cloud-bigquery==3.35.0; python_version >= '3.9'
+google-cloud-bigquery==3.35.1; python_version >= '3.9'
 google-cloud-core==2.4.3
 google-crc32c==1.7.1; python_version >= '3.9'
 google-resumable-media==2.7.2
 googleapis-common-protos==1.70.0
 greenlet==3.2.3; python_version >= '3.9'
-grpcio==1.73.1; python_version >= '3.9'
-grpcio-status==1.73.1; python_version >= '3.9'
+grpcio==1.74.0; python_version >= '3.9'
+grpcio-status==1.74.0; python_version >= '3.9'
 idna==3.10
 importlib-resources==6.5.2; python_version >= '3.9'
 mako==1.3.10; python_version >= '3.9'

--- a/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
+++ b/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
@@ -616,7 +616,7 @@ class InsertBehaviorTest(_InsertBehaviorTest):
         pass
 
 
-del ComponentReflectionTestExtra # Multiple tests re: CHECK CONSTRAINTS, etc which
+del ComponentReflectionTestExtra  # Multiple tests re: CHECK CONSTRAINTS, etc which
 del ComponentReflectionTest  # Multiple tests re: CHECK CONSTRAINTS, etc which
 # BQ does not support
 # class ComponentReflectionTest(_ComponentReflectionTest):

--- a/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
+++ b/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
@@ -57,6 +57,7 @@ from sqlalchemy.testing.suite.test_types import (
 from sqlalchemy.testing.suite.test_reflection import (
     BizarroCharacterTest,
     ComponentReflectionTest,
+    ComponentReflectionTestExtra,
     HasTableTest,
 )
 
@@ -615,6 +616,7 @@ class InsertBehaviorTest(_InsertBehaviorTest):
         pass
 
 
+del ComponentReflectionTestExtra # Multiple tests re: CHECK CONSTRAINTS, etc which
 del ComponentReflectionTest  # Multiple tests re: CHECK CONSTRAINTS, etc which
 # BQ does not support
 # class ComponentReflectionTest(_ComponentReflectionTest):

--- a/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
+++ b/tests/sqlalchemy_dialect_compliance/test_dialect_compliance.py
@@ -55,7 +55,7 @@ from sqlalchemy.testing.suite.test_types import (
 )
 
 from sqlalchemy.testing.suite.test_reflection import (
-    BizarroCharacterFKResolutionTest,
+    BizarroCharacterTest,
     ComponentReflectionTest,
     HasTableTest,
 )
@@ -629,7 +629,7 @@ del ComponentReflectionTest  # Multiple tests re: CHECK CONSTRAINTS, etc which
 #         pass
 
 del ArrayTest  # only appears to apply to postgresql
-del BizarroCharacterFKResolutionTest
+del BizarroCharacterTest
 del HasTableTest.test_has_table_cache  # TODO confirm whether BQ has table caching
 del DistinctOnTest  # expects unquoted table names.
 del HasIndexTest  # BQ doesn't do the indexes that SQLA is loooking for.


### PR DESCRIPTION
chore: updates `owlbot.py` and `renovate.json` to help control dependency when Python 3.9 is used.

Also: Edit to two local references that are causing compliance tests in this PR to fail.

* Changed the name of an upstream `sqlalchemy` test (`BizarroCharacterFKResolutionTest` -> `BizarroCharacterTest`). The sqlalchemy folks refactored the name recently.
* Historically deleted references to the compliance test `ComponentReflectionTest` because it checked for capabilities that BQ did not support. This PR also deletes references to `ComponentReflectionTestExtra` for the same reason.